### PR TITLE
Add CLI, SQLite profile storage, and agent skills

### DIFF
--- a/.agents/skills/fleece/SKILL.md
+++ b/.agents/skills/fleece/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: fleece
+description: Fleece credit card research CLI. Provides live US credit card data via Brave Search — full reports, earning rates, transfer partners, statement credits, recent news, card comparisons, portfolio analysis, ROI estimates, and profile-based recommendations. Use whenever you need current credit card information.
+---
+
+# Fleece Credit Card Research
+
+Live US credit card research backed by Brave Search. All commands output JSON for
+programmatic use. Requires `BRAVE_API_KEY` in the environment.
+
+## Prerequisites
+
+```bash
+# Set in environment or .env file
+export BRAVE_API_KEY=<your_key>
+
+# Run from the fleece project root
+cd /path/to/fleece
+```
+
+## Commands
+
+### Full card report
+```bash
+python cli.py card "<card name>" --json
+```
+Returns fees, welcome offer, earning rates, credits, benefits, and strategy.
+
+### Earning rates
+```bash
+python cli.py rates "<card name>" --json
+python cli.py rates "<card name>" --category "<dining|travel|groceries|gas>" --json
+```
+
+### Transfer partners
+```bash
+python cli.py partners "<card name>" --json
+```
+Returns airline and hotel partners with ratios and transfer timing.
+
+### Statement credits
+```bash
+python cli.py credits "<card name>" --json
+```
+Returns all credits with amounts, cadence, and enrollment requirements.
+
+### Recent news (past month)
+```bash
+python cli.py news "<card name>" --json
+```
+Freshness-filtered to the past month.
+
+### Side-by-side comparison
+```bash
+python cli.py compare "<card A>" "<card B>" --json
+python cli.py compare "<card A>" "<card B>" --aspects "fees,rewards,credits" --json
+```
+
+### Portfolio / wallet analysis
+```bash
+python cli.py wallet "<card 1>" "<card 2>" "<card 3>" --json
+```
+Returns coverage map, overlaps, gaps, and next-card suggestions.
+
+### First-year ROI
+```bash
+python cli.py roi "<card name>" --travel <monthly $> --dining <monthly $> --other <monthly $> --json
+```
+
+### Profile-based recommendations
+```bash
+python cli.py recommend "<spending profile>" --json
+python cli.py recommend "<spending profile>" --preferences "<preferences>" --json
+```
+
+## Output format
+
+Every command with `--json` returns:
+```json
+{
+  "command": "card",
+  "query": "...",
+  "result": "...",
+  "ok": true,
+  "error": null
+}
+```
+
+On error, `ok` is `false` and `error` contains the message. Always check `ok` before using `result`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Search / tool error (Brave API failure) |
+| `2` | `BRAVE_API_KEY` not set |
+
+## Stdin piping
+
+The primary argument on any single-card command accepts `-` to read from stdin:
+```bash
+echo "Chase Sapphire Preferred" | python cli.py card - --json
+echo "high dining spend" | python cli.py recommend - --json
+```
+
+The `wallet` command accepts `-` as its sole argument to read newline-delimited card names:
+```bash
+printf "Amex Gold\nChase Freedom Unlimited\nBilt\n" | python cli.py wallet - --json
+```
+
+## Coverage
+
+Supports all major US issuers: Amex, Bank of America, Barclays, Bilt, Capital One,
+Chase, Citi, Discover, Robinhood, U.S. Bank, Wells Fargo.

--- a/.claude/skills/fleece-card.md
+++ b/.claude/skills/fleece-card.md
@@ -1,0 +1,38 @@
+---
+name: fleece-card
+description: Full credit card report — fees, welcome offer, earning rates, statement credits, benefits, and strategy. Use when asked about a specific card in detail.
+---
+
+# /fleece-card
+
+Fetches a comprehensive report for a US credit card using live Brave Search data.
+
+## When to use
+- User asks about a specific card's details, benefits, or annual fee
+- User wants to know if a card is worth it
+- You need current card info (training data may be stale)
+
+## Usage
+
+```bash
+python cli.py card "<card name>" --json
+```
+
+The `--json` flag returns a structured envelope your can parse:
+```json
+{ "command": "card", "query": "...", "result": "...", "ok": true, "error": null }
+```
+
+Use `result` as your research context, then synthesize a natural answer.
+
+## Exit codes
+- `0` success
+- `1` search error — tell the user and fall back to training data
+- `2` `BRAVE_API_KEY` not configured
+
+## Example
+
+```bash
+python cli.py card "Chase Sapphire Preferred" --json
+python cli.py card "Amex Gold" --json
+```

--- a/.claude/skills/fleece-compare.md
+++ b/.claude/skills/fleece-compare.md
@@ -1,0 +1,31 @@
+---
+name: fleece-compare
+description: Side-by-side comparison of two credit cards across fees, rewards, welcome offers, credits, and transfer partners. Use when asked which card is better.
+---
+
+# /fleece-compare
+
+Searches live data for both cards and returns research for a structured comparison.
+
+## When to use
+- User asks "which is better" between two specific cards
+- User is deciding between two cards and wants a comparison
+- User wants to see how two cards stack up on a specific dimension
+
+## Usage
+
+```bash
+python cli.py compare "<card A>" "<card B>" --json
+python cli.py compare "<card A>" "<card B>" --aspects "fees,rewards,credits" --json
+```
+
+Default aspects: `fees,rewards,welcome_offer,credits,transfer_partners`
+
+## Example
+
+```bash
+python cli.py compare "Amex Gold" "Chase Sapphire Preferred" --json
+python cli.py compare "Capital One Venture X" "Chase Sapphire Reserve" --json
+```
+
+After receiving the result, synthesize a clear recommendation based on the user's stated priorities.

--- a/.claude/skills/fleece-credits.md
+++ b/.claude/skills/fleece-credits.md
@@ -1,0 +1,26 @@
+---
+name: fleece-credits
+description: Statement credits and perks for a credit card — amounts, cadence, enrollment requirements. Use when asked how to offset the annual fee or what credits are available.
+---
+
+# /fleece-credits
+
+Fetches the full list of statement credits and perks for a card.
+
+## When to use
+- User asks what credits a card offers
+- User wants to know how to offset the annual fee
+- User asks about dining, travel, streaming, or hotel credits
+
+## Usage
+
+```bash
+python cli.py credits "<card name>" --json
+```
+
+## Example
+
+```bash
+python cli.py credits "Amex Platinum" --json
+python cli.py credits "Chase Sapphire Reserve" --json
+```

--- a/.claude/skills/fleece-news.md
+++ b/.claude/skills/fleece-news.md
@@ -1,0 +1,28 @@
+---
+name: fleece-news
+description: Recent changes to a credit card in the past month — benefit cuts, fee increases, new perks, or limited-time offers. Use when asked if anything changed recently.
+---
+
+# /fleece-news
+
+Searches for the latest news and changes for a card using freshness-filtered results.
+
+## When to use
+- User asks if a card's benefits have changed recently
+- User heard something changed and wants confirmation
+- You want to verify your training data is still accurate
+
+## Usage
+
+```bash
+python cli.py news "<card name>" --json
+```
+
+Results are filtered to the past month (`freshness=pm`).
+
+## Example
+
+```bash
+python cli.py news "Amex Gold" --json
+python cli.py news "Chase Sapphire Reserve" --json
+```

--- a/.claude/skills/fleece-partners.md
+++ b/.claude/skills/fleece-partners.md
@@ -1,0 +1,27 @@
+---
+name: fleece-partners
+description: Transfer partners for a credit card's rewards program — airlines and hotels, transfer ratios, and timing. Use when asked about moving points or miles.
+---
+
+# /fleece-partners
+
+Fetches transfer partner details for a card's rewards currency.
+
+## When to use
+- User asks what airlines or hotels they can transfer points to
+- User wants to know transfer ratios or how long transfers take
+- User is planning a specific redemption and needs partner details
+
+## Usage
+
+```bash
+python cli.py partners "<card name>" --json
+```
+
+## Example
+
+```bash
+python cli.py partners "Chase Sapphire Preferred" --json
+python cli.py partners "Capital One Venture X" --json
+python cli.py partners "Amex Platinum" --json
+```

--- a/.claude/skills/fleece-rates.md
+++ b/.claude/skills/fleece-rates.md
@@ -1,0 +1,29 @@
+---
+name: fleece-rates
+description: Earning rates for a credit card by spend category — points, miles, or cash back per dollar. Optionally filter to a specific category like dining or travel.
+---
+
+# /fleece-rates
+
+Looks up earning rates for a credit card, with optional category filtering.
+
+## When to use
+- User asks how many points/miles/cash back a card earns
+- User wants to know the best card for a specific spend category
+- You need to compare multipliers across categories
+
+## Usage
+
+```bash
+python cli.py rates "<card name>" --json
+python cli.py rates "<card name>" --category "<category>" --json
+```
+
+Categories: `dining`, `travel`, `groceries`, `gas`, `streaming`, `drugstores`, etc.
+
+## Example
+
+```bash
+python cli.py rates "Chase Sapphire Preferred" --json
+python cli.py rates "Amex Gold" --category dining --json
+```

--- a/.claude/skills/fleece-recommend.md
+++ b/.claude/skills/fleece-recommend.md
@@ -1,0 +1,32 @@
+---
+name: fleece-recommend
+description: Card recommendations matched to a spending profile and preferences. Use when the user asks for the best card for their situation without naming a specific card.
+---
+
+# /fleece-recommend
+
+Searches for best-match US credit cards for a given spending profile.
+
+## When to use
+- User asks "what's the best card for me?"
+- User describes their spending habits and wants recommendations
+- User states a preference (no annual fee, travel perks, cash back, etc.)
+
+## Usage
+
+```bash
+python cli.py recommend "<spending profile>" --json
+python cli.py recommend "<spending profile>" --preferences "<extra preferences>" --json
+```
+
+Keep the profile concise: categories + rough amounts or priorities.
+
+## Example
+
+```bash
+python cli.py recommend "high dining and travel spend, $500/mo dining, $300/mo travel" --json
+python cli.py recommend "everyday spending, mostly groceries and gas" --preferences "no annual fee" --json
+python cli.py recommend "frequent international traveler" --preferences "priority pass lounge access" --json
+```
+
+After receiving results, present 2–3 top recommendations with a brief rationale for each.

--- a/.claude/skills/fleece-roi.md
+++ b/.claude/skills/fleece-roi.md
@@ -1,0 +1,31 @@
+---
+name: fleece-roi
+description: First-year ROI estimate for a credit card given monthly spend on travel, dining, and other. Calculates welcome bonus value + earn + credits minus annual fee.
+---
+
+# /fleece-roi
+
+Estimates first-year return on investment for a card based on the user's spending.
+
+## When to use
+- User asks if a card is worth it for them specifically
+- User provides their spending habits and wants a value estimate
+- User wants to compare first-year value across cards
+
+## Usage
+
+```bash
+python cli.py roi "<card name>" --travel <monthly $> --dining <monthly $> --other <monthly $> --json
+```
+
+All spend flags are optional and default to `0`. Omit any category the user didn't mention.
+
+## Example
+
+```bash
+python cli.py roi "Chase Sapphire Preferred" --travel 500 --dining 300 --other 1000 --json
+python cli.py roi "Amex Gold" --dining 800 --other 500 --json
+```
+
+The result includes annual spend totals, an assumed cents-per-point value, and live research context.
+Present the math clearly and note that exact welcome bonus amounts should be verified with the issuer.

--- a/.claude/skills/fleece-wallet.md
+++ b/.claude/skills/fleece-wallet.md
@@ -1,0 +1,30 @@
+---
+name: fleece-wallet
+description: Portfolio analysis for a set of cards the user holds — category coverage map, overlaps, gaps, and next-card suggestions. Use when asked how to maximize an existing wallet.
+---
+
+# /fleece-wallet
+
+Analyzes a multi-card portfolio and identifies optimization opportunities.
+
+## When to use
+- User lists their current cards and asks how to maximize
+- User asks what category gaps exist in their wallet
+- User asks which card to use for a specific purchase given what they hold
+
+## Usage
+
+```bash
+python cli.py wallet "<card 1>" "<card 2>" "<card 3>" --json
+```
+
+Pass each card as a separate quoted argument.
+
+## Example
+
+```bash
+python cli.py wallet "Amex Platinum" "Chase Freedom Unlimited" "Bilt" --json
+python cli.py wallet "Amex Gold" "Chase Sapphire Preferred" "Citi Double Cash" --json
+```
+
+The result includes a coverage map, overlaps, gaps, and 1–2 complementary card suggestions.

--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,8 @@ dmypy.json
 
 .idea
 .env
+user_cards.json
+user_cards.json.bak
+fleece.db
 
 user_cards.json

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,391 @@
+"""
+Fleece CLI — agent-friendly companion to the Fleece Streamlit chatbot.
+
+Exposes credit card research tools as shell commands backed by Brave Search.
+Designed for use by AI agents (Claude Code, Codex) and humans alike.
+
+Exit codes:
+  0  success
+  1  search / tool error
+  2  configuration error (missing API key)
+"""
+import json
+import sys
+from typing import Annotated, Optional
+
+import typer
+from dotenv import load_dotenv
+
+app = typer.Typer(
+    name="fleece",
+    help="Fleece credit card research CLI — live data via Brave Search.",
+    no_args_is_help=True,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_key(api_key: Optional[str], no_dotenv: bool) -> str:
+    """Load env and return the Brave API key, or exit with code 2."""
+    import os
+    if not no_dotenv:
+        load_dotenv()
+    key = api_key or os.getenv("BRAVE_API_KEY", "")
+    if not key:
+        _error_exit(
+            "BRAVE_API_KEY not set. Pass --api-key or add it to .env.",
+            code=2,
+        )
+    return key
+
+
+def _get_wrapper(key: str, freshness: Optional[str] = None):
+    from tools.brave_client import build_brave_wrapper
+    return build_brave_wrapper(key, freshness=freshness)
+
+
+def _read_stdin_or_arg(value: str) -> str:
+    """If value is '-', read the first line from stdin."""
+    if value == "-":
+        return sys.stdin.readline().strip()
+    return value
+
+
+def _emit(result: str, as_json: bool, command: str, query: str) -> None:
+    if as_json:
+        typer.echo(json.dumps({"command": command, "query": query, "result": result, "ok": True, "error": None}))
+    else:
+        typer.echo(result)
+
+
+def _error_exit(message: str, code: int = 1) -> None:
+    typer.echo(
+        json.dumps({"ok": False, "error": message}),
+        err=True,
+    )
+    raise typer.Exit(code=code)
+
+
+def _run_search(wrapper, query: str, command: str, as_json: bool) -> None:
+    from tools.brave_client import search_and_format
+    try:
+        result = search_and_format(wrapper, query)
+        _emit(result, as_json, command, query)
+    except Exception as e:
+        _error_exit(str(e), code=1)
+
+
+# ---------------------------------------------------------------------------
+# User profile helpers (fleece.db)
+# ---------------------------------------------------------------------------
+
+def _load_profile() -> list[dict]:
+    import db
+    return db.get_cards()
+
+
+def _profile_card_names() -> list[str]:
+    import db
+    return db.get_card_names()
+
+
+# Reusable option annotations
+ApiKeyOpt     = Annotated[Optional[str], typer.Option("--api-key", help="Override BRAVE_API_KEY env var.")]
+JsonOpt       = Annotated[bool, typer.Option("--json", "-j", help="Emit JSON output (agent-friendly).")]
+NoDotenv      = Annotated[bool, typer.Option("--no-dotenv", help="Skip loading .env file.")]
+FromProfileOpt = Annotated[bool, typer.Option("--from-profile", "-p", help="Use cards saved in user_cards.json instead of passing names.")]
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+@app.command()
+def card(
+    name:      Annotated[str, typer.Argument(help="Card name. Use '-' to read from stdin.")],
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """Full card report — fees, welcome offer, earning rates, credits, benefits, strategy."""
+    name = _read_stdin_or_arg(name)
+    key  = _resolve_key(api_key, no_dotenv)
+    query = f'"{name}" credit card annual fee welcome offer earning rates benefits credits 2025'
+    _run_search(_get_wrapper(key), query, "card", as_json)
+
+
+@app.command()
+def rates(
+    name:      Annotated[str, typer.Argument(help="Card name. Use '-' to read from stdin.")],
+    category:  Annotated[Optional[str], typer.Option("--category", "-c", help="Spending category (dining, travel, groceries…)")] = None,
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """Earning rates by spend category — points, miles, or cash back per dollar."""
+    name = _read_stdin_or_arg(name)
+    key  = _resolve_key(api_key, no_dotenv)
+    cat  = f"{category} " if category else ""
+    query = f'"{name}" {cat}earning rates points miles cashback per dollar categories 2025'
+    _run_search(_get_wrapper(key), query, "rates", as_json)
+
+
+@app.command()
+def partners(
+    name:      Annotated[str, typer.Argument(help="Card name. Use '-' to read from stdin.")],
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """Transfer partners — airlines and hotels, ratios, and transfer timing."""
+    name = _read_stdin_or_arg(name)
+    key  = _resolve_key(api_key, no_dotenv)
+    query = f'"{name}" transfer partners airlines hotels ratio transfer time 2025'
+    _run_search(_get_wrapper(key), query, "partners", as_json)
+
+
+@app.command()
+def credits(
+    name:      Annotated[str, typer.Argument(help="Card name. Use '-' to read from stdin.")],
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """Statement credits and perks — amounts, cadence, and enrollment requirements."""
+    name = _read_stdin_or_arg(name)
+    key  = _resolve_key(api_key, no_dotenv)
+    query = f'"{name}" statement credits perks benefits complete list how to use 2025'
+    _run_search(_get_wrapper(key), query, "credits", as_json)
+
+
+@app.command()
+def news(
+    name:      Annotated[str, typer.Argument(help="Card name. Use '-' to read from stdin.")],
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """Recent changes in the past month — fee increases, benefit cuts, new perks."""
+    name = _read_stdin_or_arg(name)
+    key  = _resolve_key(api_key, no_dotenv)
+    query = f'"{name}" credit card changes update news 2025'
+    _run_search(_get_wrapper(key, freshness="pm"), query, "news", as_json)
+
+
+@app.command()
+def compare(
+    card_a:    Annotated[str, typer.Argument(help="First card name.")],
+    card_b:    Annotated[str, typer.Argument(help="Second card name.")],
+    aspects:   Annotated[str, typer.Option("--aspects", help="Comma-separated aspects to compare.")] = "fees,rewards,welcome_offer,credits,transfer_partners",
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """Side-by-side card comparison across fees, rewards, credits, and transfer partners."""
+    from tools.brave_client import search_and_format
+    key     = _resolve_key(api_key, no_dotenv)
+    wrapper = _get_wrapper(key)
+    asp     = aspects.replace(",", ", ")
+
+    try:
+        result_a = search_and_format(wrapper, f'"{card_a}" credit card {asp} 2025')
+        result_b = search_and_format(wrapper, f'"{card_b}" credit card {asp} 2025')
+        combined = f"## {card_a}\n{result_a}\n\n## {card_b}\n{result_b}"
+    except Exception as e:
+        _error_exit(str(e), code=1)
+        return
+    query    = f"{card_a} vs {card_b}"
+    _emit(combined, as_json, "compare", query)
+
+
+@app.command()
+def wallet(
+    cards:        Annotated[Optional[list[str]], typer.Argument(help="Card names (space-separated). Omit to use saved profile. Use '-' as sole arg to read from stdin.")] = None,
+    from_profile: FromProfileOpt = False,
+    api_key:      ApiKeyOpt  = None,
+    as_json:      JsonOpt    = False,
+    no_dotenv:    NoDotenv   = False,
+):
+    """Portfolio analysis — category coverage map, overlaps, gaps, and next-card suggestions.
+
+    Card names can come from three sources (in priority order):
+    1. Arguments passed directly
+    2. --from-profile / -p  (reads user_cards.json)
+    3. No args + saved profile exists (auto-loads profile)
+    """
+    from tools.brave_client import search_and_format
+
+    # Resolve card list
+    if cards and cards != ["-"]:
+        card_list = cards
+    elif cards == ["-"]:
+        card_list = [line.strip() for line in sys.stdin if line.strip()]
+    else:
+        # No args passed — fall back to saved profile
+        card_list = _profile_card_names()
+        if not card_list:
+            _error_exit(
+                "No cards provided and user_cards.json is empty. "
+                "Pass card names as arguments or add cards with: python cli.py cards add \"<name>\"",
+                code=1,
+            )
+
+    key     = _resolve_key(api_key, no_dotenv)
+    wrapper = _get_wrapper(key)
+    parts   = []
+
+    try:
+        for name in card_list:
+            result = search_and_format(wrapper, f'"{name}" earning rates categories benefits 2025', max_results=2)
+            parts.append(f"### {name}\n{result}")
+    except Exception as e:
+        _error_exit(str(e), code=1)
+
+    combined = "\n\n".join(parts)
+    combined += (
+        "\n\nBased on the above, identify:\n"
+        "1. Category coverage map\n"
+        "2. Overlapping benefits or redundant categories\n"
+        "3. Gaps — categories with no bonus multiplier\n"
+        "4. Top 1-2 cards that would complement this portfolio"
+    )
+    _emit(combined, as_json, "wallet", ", ".join(card_list))
+
+
+@app.command()
+def roi(
+    name:      Annotated[str, typer.Argument(help="Card name. Use '-' to read from stdin.")],
+    travel:    Annotated[float, typer.Option("--travel",  help="Monthly travel spend ($).")] = 0.0,
+    dining:    Annotated[float, typer.Option("--dining",  help="Monthly dining spend ($).")] = 0.0,
+    other:     Annotated[float, typer.Option("--other",   help="Monthly other spend ($).")] = 0.0,
+    api_key:   ApiKeyOpt  = None,
+    as_json:   JsonOpt    = False,
+    no_dotenv: NoDotenv   = False,
+):
+    """First-year ROI estimate — welcome bonus + earn + credits minus annual fee."""
+    from tools.brave_client import search_and_format
+    from tools.credit_card_tools import _guess_cpp
+
+    name = _read_stdin_or_arg(name)
+    key  = _resolve_key(api_key, no_dotenv)
+
+    annual_travel = travel * 12
+    annual_dining = dining * 12
+    annual_other  = other  * 12
+    cpp = _guess_cpp(name)
+
+    try:
+        research = search_and_format(
+            _get_wrapper(key),
+            f'"{name}" annual fee welcome bonus points value first year 2025',
+        )
+        result = (
+            f"Annual spend — Travel: ${annual_travel:,.0f} | Dining: ${annual_dining:,.0f} | Other: ${annual_other:,.0f}\n"
+            f"Assumed value per point: {cpp}¢\n\n"
+            f"Live research:\n{research}\n\n"
+            "Calculate net first-year value: welcome bonus value + estimated annual earn + credits - annual fee. Show the math."
+        )
+    except Exception as e:
+        _error_exit(str(e), code=1)
+        return
+
+    _emit(result, as_json, "roi", name)
+
+
+@app.command()
+def recommend(
+    profile:     Annotated[str, typer.Argument(help="Spending profile description. Use '-' to read from stdin.")],
+    preferences: Annotated[Optional[str], typer.Option("--preferences", "-p", help="Extra preferences (e.g. 'no annual fee').")] = None,
+    api_key:     ApiKeyOpt  = None,
+    as_json:     JsonOpt    = False,
+    no_dotenv:   NoDotenv   = False,
+):
+    """Card recommendations matched to a spending profile and preferences."""
+    profile = _read_stdin_or_arg(profile)
+    key     = _resolve_key(api_key, no_dotenv)
+    pref    = f"{preferences} " if preferences else ""
+    query   = f"best credit cards {profile} {pref}US 2025 site:nerdwallet.com OR site:thepointsguy.com OR site:doctorofcredit.com"
+    _run_search(_get_wrapper(key), query, "recommend", as_json)
+
+
+# ---------------------------------------------------------------------------
+# cards — profile management (read/write user_cards.json)
+# ---------------------------------------------------------------------------
+
+cards_app = typer.Typer(name="cards", help="Manage your saved card profile (user_cards.json).", no_args_is_help=True)
+app.add_typer(cards_app)
+
+
+@cards_app.command("list")
+def cards_list(
+    as_json: JsonOpt = False,
+):
+    """List all cards saved in your profile."""
+    profile = _load_profile()
+    if not profile:
+        typer.echo("No cards in profile. Add one with: python cli.py cards add \"<card name>\"")
+        return
+    if as_json:
+        typer.echo(json.dumps({"command": "cards list", "cards": profile, "ok": True, "error": None}))
+    else:
+        for i, card in enumerate(profile, 1):
+            fee = card.get("annual_fee", "N/A")
+            typer.echo(f"{i}. {card['name']}  (fee: {fee})")
+
+
+@cards_app.command("add")
+def cards_add(
+    name:       Annotated[str, typer.Argument(help="Card name to add.")],
+    annual_fee: Annotated[str, typer.Option("--fee", help="Annual fee (e.g. $95).")] = "$0",
+    as_json:    JsonOpt = False,
+):
+    """Add a card to your profile."""
+    import datetime
+    import db
+    new_card = {
+        "name": name,
+        "annual_fee": annual_fee,
+        "date_added": datetime.date.today().isoformat(),
+    }
+    try:
+        db.add_card(new_card)
+    except ValueError as e:
+        _error_exit(str(e), code=1)
+    total = len(db.get_card_names())
+    if as_json:
+        typer.echo(json.dumps({"command": "cards add", "card": new_card, "ok": True, "error": None}))
+    else:
+        typer.echo(f'Added "{name}" to your profile. ({total} card(s) total)')
+
+
+@cards_app.command("remove")
+def cards_remove(
+    name:    Annotated[str, typer.Argument(help="Card name to remove (partial match OK).")],
+    as_json: JsonOpt = False,
+):
+    """Remove a card from your profile."""
+    import db
+    # Partial match against all names
+    all_cards = db.get_cards()
+    matches = [c for c in all_cards if name.lower() in c["name"].lower()]
+    if not matches:
+        _error_exit(f'No card matching "{name}" found in profile.', code=1)
+    if len(matches) > 1:
+        names = ", ".join(f'"{c["name"]}"' for c in matches)
+        _error_exit(f'Ambiguous match — found {names}. Be more specific.', code=1)
+    removed = matches[0]
+    db.remove_card(removed["name"])
+    remaining = len(db.get_card_names())
+    if as_json:
+        typer.echo(json.dumps({"command": "cards remove", "removed": removed["name"], "ok": True, "error": None}))
+    else:
+        typer.echo(f'Removed "{removed["name"]}" from your profile. ({remaining} card(s) remaining)')
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    app()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,162 @@
+"""
+SQLite persistence layer for Fleece user card profiles.
+
+Database file: fleece.db (project root, next to this file).
+Shared between the Streamlit UI and the CLI — both import this module directly.
+"""
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+DB_PATH = Path(__file__).parent / "fleece.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS cards (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT    NOT NULL UNIQUE,
+    last_four    TEXT    NOT NULL DEFAULT '',
+    annual_fee   TEXT    NOT NULL DEFAULT '$0',
+    credit_limit INTEGER NOT NULL DEFAULT 0,
+    rewards      TEXT    NOT NULL DEFAULT '',
+    expiration   TEXT    NOT NULL DEFAULT '',
+    image_url    TEXT    NOT NULL DEFAULT '',
+    date_added   TEXT    NOT NULL DEFAULT (date('now'))
+);
+"""
+
+_COLUMNS = ("id", "name", "last_four", "annual_fee", "credit_limit",
+            "rewards", "expiration", "image_url", "date_added")
+
+
+@contextmanager
+def _conn() -> Iterator[sqlite3.Connection]:
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    try:
+        yield con
+        con.commit()
+    finally:
+        con.close()
+
+
+def init_db() -> None:
+    """Create tables if they don't exist. Safe to call on every startup."""
+    with _conn() as con:
+        con.executescript(_SCHEMA)
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict:
+    return dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+def get_cards() -> list[dict]:
+    """Return all cards ordered by date_added desc."""
+    init_db()
+    with _conn() as con:
+        rows = con.execute("SELECT * FROM cards ORDER BY date_added DESC").fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+def get_card_names() -> list[str]:
+    """Return just the card names — used by the CLI wallet/roi commands."""
+    init_db()
+    with _conn() as con:
+        rows = con.execute("SELECT name FROM cards ORDER BY date_added DESC").fetchall()
+    return [r["name"] for r in rows]
+
+
+def get_card(name: str) -> dict | None:
+    """Return a single card by exact name, or None."""
+    init_db()
+    with _conn() as con:
+        row = con.execute("SELECT * FROM cards WHERE name = ?", (name,)).fetchone()
+    return _row_to_dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Write
+# ---------------------------------------------------------------------------
+
+def add_card(card: dict) -> None:
+    """Insert a new card. Raises ValueError if name already exists."""
+    init_db()
+    with _conn() as con:
+        try:
+            con.execute(
+                """
+                INSERT INTO cards (name, last_four, annual_fee, credit_limit,
+                                   rewards, expiration, image_url, date_added)
+                VALUES (:name, :last_four, :annual_fee, :credit_limit,
+                        :rewards, :expiration, :image_url, :date_added)
+                """,
+                {
+                    "name":         card.get("name", ""),
+                    "last_four":    card.get("last_four", ""),
+                    "annual_fee":   card.get("annual_fee", "$0"),
+                    "credit_limit": card.get("credit_limit", 0),
+                    "rewards":      card.get("rewards", ""),
+                    "expiration":   card.get("expiration", ""),
+                    "image_url":    card.get("image_url", ""),
+                    "date_added":   card.get("date_added", ""),
+                },
+            )
+        except sqlite3.IntegrityError:
+            raise ValueError(f'Card "{card.get("name")}" already exists.')
+
+
+def update_card(name: str, updates: dict) -> bool:
+    """Update fields on an existing card. Returns True if found."""
+    if not updates:
+        return False
+    allowed = set(_COLUMNS) - {"id", "name", "date_added"}
+    fields = {k: v for k, v in updates.items() if k in allowed}
+    if not fields:
+        return False
+    init_db()
+    set_clause = ", ".join(f"{k} = :{k}" for k in fields)
+    fields["_name"] = name
+    with _conn() as con:
+        cur = con.execute(f"UPDATE cards SET {set_clause} WHERE name = :_name", fields)
+    return cur.rowcount > 0
+
+
+def remove_card(name: str) -> bool:
+    """Delete a card by exact name. Returns True if it existed."""
+    init_db()
+    with _conn() as con:
+        cur = con.execute("DELETE FROM cards WHERE name = ?", (name,))
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+def migrate_from_json(json_path: Path) -> int:
+    """
+    Import cards from a JSON file into SQLite. Skips duplicates.
+    Returns the number of cards inserted.
+    """
+    import json
+
+    if not json_path.exists():
+        return 0
+
+    raw = json.loads(json_path.read_text())
+    if not isinstance(raw, list):
+        return 0
+
+    init_db()
+    inserted = 0
+    for card in raw:
+        try:
+            add_card(card)
+            inserted += 1
+        except ValueError:
+            pass  # already exists — skip
+    return inserted

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Install Fleece skills for Claude Code and/or OpenClaw / Codex agents.
+#
+# Usage:
+#   bash install.sh           # auto-detect
+#   bash install.sh --claude  # Claude Code only
+#   bash install.sh --agents  # OpenClaw / Codex only
+#   bash install.sh --all     # both
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+install_claude() {
+  TARGET=".claude/skills"
+  mkdir -p "$TARGET"
+  for f in "$SCRIPT_DIR"/.claude/skills/fleece-*.md; do
+    dest="$TARGET/$(basename "$f")"
+    [ "$(realpath "$f")" = "$(realpath "$dest" 2>/dev/null)" ] && continue
+    cp "$f" "$dest"
+  done
+  echo "✓ Claude Code skills installed to $TARGET/"
+  echo "  Slash commands: /fleece-card /fleece-rates /fleece-partners /fleece-credits"
+  echo "                  /fleece-news /fleece-compare /fleece-wallet /fleece-roi /fleece-recommend"
+}
+
+install_agents() {
+  TARGET=".agents/skills/fleece"
+  mkdir -p "$TARGET"
+  src="$SCRIPT_DIR/.agents/skills/fleece/SKILL.md"
+  dest="$TARGET/SKILL.md"
+  [ "$(realpath "$src")" != "$(realpath "$dest" 2>/dev/null)" ] && cp "$src" "$dest"
+  echo "✓ Agent skill installed to $TARGET/SKILL.md"
+}
+
+auto_detect() {
+  INSTALLED=0
+  if [ -d ".claude" ]; then
+    install_claude
+    INSTALLED=1
+  fi
+  if [ -d ".agents" ]; then
+    install_agents
+    INSTALLED=1
+  fi
+  if [ "$INSTALLED" -eq 0 ]; then
+    echo "No .claude or .agents directory found. Pass --claude, --agents, or --all."
+    exit 1
+  fi
+}
+
+case "${1:-auto}" in
+  --claude) install_claude ;;
+  --agents) install_agents ;;
+  --all)    install_claude; install_agents ;;
+  auto)     auto_detect ;;
+  *)        echo "Usage: bash install.sh [--claude|--agents|--all]"; exit 1 ;;
+esac
+
+echo ""
+echo "Set BRAVE_API_KEY in your environment or .env file to enable live research."

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,38 @@
+"""
+One-shot migration: user_cards.json → fleece.db
+
+Run once:
+    python migrate.py
+
+What it does:
+  1. Creates fleece.db and the cards table if not already present
+  2. Imports all cards from user_cards.json
+  3. Renames user_cards.json → user_cards.json.bak (preserves original)
+"""
+from pathlib import Path
+
+import db
+
+JSON_FILE = Path(__file__).parent / "user_cards.json"
+BAK_FILE  = JSON_FILE.with_suffix(".json.bak")
+
+
+def main() -> None:
+    if not JSON_FILE.exists():
+        print("user_cards.json not found — nothing to migrate.")
+        return
+
+    count = db.migrate_from_json(JSON_FILE)
+    print(f"Migrated {count} card(s) to fleece.db.")
+
+    JSON_FILE.rename(BAK_FILE)
+    print(f"Original file preserved at {BAK_FILE.name}")
+
+    cards = db.get_cards()
+    print(f"\nCards now in database ({len(cards)} total):")
+    for c in cards:
+        print(f"  • {c['name']}  (fee: {c['annual_fee']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/my_credit_cards.py
+++ b/pages/my_credit_cards.py
@@ -20,16 +20,17 @@ Features:
 Author: @chenyuan99
 Date: May 2025
 """
-import streamlit as st
-import pandas as pd
-from PIL import Image
-import os
-import io
-import requests
-from io import BytesIO
-import json
 import datetime
-from image_service import  display_card_image
+import os
+import sys
+
+import pandas as pd
+import streamlit as st
+
+# Ensure project root is on sys.path so db.py is importable from the pages/ dir
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import db
+from image_service import display_card_image
 # Set page configuration
 st.set_page_config(page_title="My Credit Cards | Fleece", layout="wide")
 
@@ -55,64 +56,14 @@ except Exception as e:
 st.title("My Credit Cards")
 st.subheader("Manage your current credit card portfolio")
 
-# File path for storing user's credit cards
-USER_CARDS_FILE = os.path.join(os.path.dirname(__file__), "..", "user_cards.json")
-
-# Function to load user's credit cards with caching
-@st.cache_data(ttl=300)  # Cache for 5 minutes
+@st.cache_data(ttl=300)
 def load_user_cards():
-    """
-    Load the user's credit cards from the JSON file with caching for improved performance.
-    
-    This function reads the user's credit cards from a JSON file and caches the result
-    for 5 minutes to avoid unnecessary file I/O operations. If the file doesn't exist
-    or there's an error reading it, an empty list is returned.
-    
-    Returns:
-        list: A list of dictionaries, each containing details about a user's credit card
-              with keys such as name, last_four, annual_fee, credit_limit, rewards,
-              expiration, image_url, and date_added.
-    
-    Performance Notes:
-        - Uses Streamlit's caching with a 5-minute TTL to balance freshness and performance
-        - Returns an empty list as fallback if the file doesn't exist or can't be read
-    """
-    if os.path.exists(USER_CARDS_FILE):
-        try:
-            with open(USER_CARDS_FILE, 'r') as f:
-                return json.load(f)
-        except Exception as e:
-            st.error(f"Error loading your cards: {e}")
-            return []
-    else:
-        return []
-
-# Function to save user's credit cards
-def save_user_cards(cards):
-    """
-    Save the user's credit cards to the JSON file.
-    
-    This function writes the user's credit cards to a JSON file with proper formatting.
-    If there's an error during the save operation, an error message is displayed and
-    False is returned.
-    
-    Args:
-        cards (list): A list of dictionaries, each containing details about a user's credit card
-    
-    Returns:
-        bool: True if the save operation was successful, False otherwise
-    
-    Note:
-        After a successful save operation, you should clear the load_user_cards cache
-        using load_user_cards.clear() to ensure fresh data is loaded on the next read.
-    """
+    """Load cards from SQLite with a 5-minute cache."""
     try:
-        with open(USER_CARDS_FILE, 'w') as f:
-            json.dump(cards, f, indent=2)
-        return True
+        return db.get_cards()
     except Exception as e:
-        st.error(f"Error saving your cards: {e}")
-        return False
+        st.error(f"Error loading your cards: {e}")
+        return []
 
 # Load user's credit cards
 user_cards = load_user_cards()
@@ -255,12 +206,10 @@ with tab1:
                         col1, col2 = st.columns(2)
                         with col1:
                             if st.button(f"Remove Card", key=f"remove_{i}"):
-                                user_cards.remove(card)
-                                if save_user_cards(user_cards):
-                                    st.success(f"Removed {card['name']} from your cards!")
-                                    # Clear cache to reload cards
-                                    load_user_cards.clear()
-                                    st.rerun()
+                                db.remove_card(card['name'])
+                                st.success(f"Removed {card['name']} from your cards!")
+                                load_user_cards.clear()
+                                st.rerun()
                         
                         with col2:
                             if st.button(f"Edit Details", key=f"edit_{i}"):
@@ -282,20 +231,18 @@ with tab1:
                 
                 submitted = st.form_submit_button("Save Changes")
                 if submitted:
-                    # Update card details
-                    user_cards[st.session_state['edit_index']]['name'] = name
-                    user_cards[st.session_state['edit_index']]['last_four'] = last_four
-                    user_cards[st.session_state['edit_index']]['annual_fee'] = annual_fee
-                    user_cards[st.session_state['edit_index']]['credit_limit'] = credit_limit
-                    user_cards[st.session_state['edit_index']]['rewards'] = rewards
-                    user_cards[st.session_state['edit_index']]['expiration'] = expiration
-                    
-                    if save_user_cards(user_cards):
-                        st.success("Card details updated successfully!")
-                        # Clear the edit state and refresh
-                        del st.session_state['edit_card']
-                        del st.session_state['edit_index']
-                        st.rerun()
+                    db.update_card(st.session_state['edit_card']['name'], {
+                        "last_four":    last_four,
+                        "annual_fee":   annual_fee,
+                        "credit_limit": credit_limit,
+                        "rewards":      rewards,
+                        "expiration":   expiration,
+                    })
+                    st.success("Card details updated successfully!")
+                    load_user_cards.clear()
+                    del st.session_state['edit_card']
+                    del st.session_state['edit_index']
+                    st.rerun()
 
 # Tab 2: Add New Card
 with tab2:
@@ -333,26 +280,23 @@ with tab2:
         
         submitted = st.form_submit_button("Add Card")
         if submitted:
-            # Create new card entry
             new_card = {
-                "name": name,
-                "last_four": last_four,
-                "annual_fee": annual_fee,
+                "name":         name,
+                "last_four":    last_four,
+                "annual_fee":   annual_fee,
                 "credit_limit": credit_limit,
-                "rewards": rewards,
-                "expiration": expiration,
-                "image_url": image_url,
-                "date_added": datetime.datetime.now().strftime("%Y-%m-%d")
+                "rewards":      rewards,
+                "expiration":   expiration,
+                "image_url":    image_url,
+                "date_added":   datetime.datetime.now().strftime("%Y-%m-%d"),
             }
-            
-            # Add to user's cards
-            user_cards.append(new_card)
-            
-            # Save updated cards
-            if save_user_cards(user_cards):
+            try:
+                db.add_card(new_card)
+                load_user_cards.clear()
                 st.success(f"Added {name} to your cards!")
-                # Switch to the My Cards tab
                 st.rerun()
+            except ValueError:
+                st.error(f'"{name}" is already in your cards.')
 
 # Add a section for card statistics and insights
 if user_cards:

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,175 @@
+  # cli.py — Fleece Companion CLI Plan
+
+## Purpose
+
+A Typer-based CLI that exposes Fleece's credit card research tools as shell commands.
+Primary consumers: AI agents (Claude Code, OpenAI Codex, future agentic tools) that need
+to query live credit card data without running the Streamlit UI. Also usable by humans.
+
+---
+
+## Design Philosophy
+
+**Agent-first, human-friendly.**
+
+Agents need:
+- Machine-readable output (JSON) they can parse without regex
+- Deterministic exit codes (0 = success, 1 = tool error, 2 = config error)
+- No interactive prompts — all inputs via args/flags
+- Self-describing `--help` text so agents can discover commands without docs
+- Stdin piping support for chaining commands
+
+Humans need:
+- Readable plain-text output by default
+- Sensible defaults (no flags required for simple queries)
+- Fast feedback on missing API key
+
+---
+
+## Command Structure
+
+```
+fleece <command> [args] [options]
+```
+
+### Commands
+
+| Command | Args | Key Flags | Description |
+|---|---|---|---|
+| `card` | `name` | `--json` | Full card report (fees, offer, earnings, credits, benefits) |
+| `rates` | `name` | `--category`, `--json` | Earning rates, optionally filtered by spend category |
+| `partners` | `name` | `--json` | Transfer partners with ratios |
+| `credits` | `name` | `--json` | Statement credits and perks |
+| `news` | `name` | `--json` | Changes in the past month |
+| `compare` | `card-a`, `card-b` | `--aspects`, `--json` | Side-by-side comparison |
+| `wallet` | `cards...` | `--json` | Portfolio gap/overlap analysis (variadic: multiple cards) |
+| `roi` | `name` | `--travel`, `--dining`, `--other`, `--json` | First-year ROI given monthly spend |
+| `recommend` | `profile` | `--preferences`, `--json` | Card recommendations for a spending profile |
+
+### Global Options (on every command)
+
+| Flag | Default | Description |
+|---|---|---|
+| `--json / -j` | False | Emit JSON instead of plain text |
+| `--api-key` | env | Override `BRAVE_API_KEY` (fallback to `.env`) |
+| `--no-dotenv` | False | Skip loading `.env` file |
+
+---
+
+## Output Format
+
+### Plain text (default — human)
+Raw string result from the research tool, printed to stdout.
+
+### JSON mode (`--json`)
+```json
+{
+  "command": "card",
+  "query": "Chase Sapphire Preferred",
+  "result": "...",
+  "ok": true,
+  "error": null
+}
+```
+
+Errors always emit JSON with `"ok": false` and `"error": "<message>"` to stderr,
+regardless of `--json` flag, so agents can always parse failure.
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Search/tool error (Brave API failure, timeout) |
+| `2` | Configuration error (missing API key) |
+
+---
+
+## File Structure
+
+```
+fleece/
+├── cli.py                  # NEW: Typer app, all commands
+├── tools/
+│   ├── brave_client.py     # existing
+│   ├── credit_card_tools.py # existing — cli.py calls tool fns directly, not via LangChain
+│   └── __init__.py
+├── requirements.txt        # add: typer[all]
+└── tests/
+    └── test_cli.py         # NEW: CLI tests via typer.testing.CliRunner
+```
+
+### Key architectural decision
+`cli.py` calls the underlying search functions in `tools/brave_client.py` **directly**,
+bypassing the LangChain tool wrappers. This avoids pulling in the full LangChain agent
+stack for a simple CLI query. The LangChain `@tool` decorators stay on
+`credit_card_tools.py` for the Streamlit agent — the CLI is a thinner layer.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Add typer to requirements.txt
+`typer[all]>=0.12.0` (includes `rich` for pretty output)
+
+### Step 2 — Create cli.py skeleton
+- `app = typer.Typer(name="fleece", help="Fleece credit card research CLI")`
+- Shared `_get_wrapper(api_key, freshness)` helper that loads `.env`, resolves key, exits
+  with code 2 if missing
+- Shared `_emit(result, as_json, command, query)` helper that prints plain or JSON
+
+### Step 3 — Implement simple single-arg commands
+`card`, `rates`, `partners`, `credits`, `news` — each is ~10 lines:
+1. Build wrapper via `_get_wrapper()`
+2. Call `search_and_format(wrapper, query)`
+3. Call `_emit(result, ...)`
+
+### Step 4 — Implement multi-arg commands
+- `compare` — takes two positional args, calls `search_and_format` twice, merges output
+- `wallet` — variadic `cards: list[str]`, loops over each card
+- `roi` — float flags `--travel`, `--dining`, `--other`; calls search + formats spend math
+- `recommend` — takes `profile` positional + optional `--preferences`
+
+### Step 5 — Add stdin support
+If a command's primary arg is `-`, read from stdin:
+```bash
+echo "Chase Sapphire Preferred" | python cli.py card -
+```
+Useful for agent pipelines.
+
+### Step 6 — Write tests/test_cli.py
+Use `typer.testing.CliRunner` to invoke each command with a mocked `search_and_format`.
+Test: success path, JSON output, missing API key (exit code 2), search error (exit code 1).
+
+---
+
+## Usage Examples
+
+### Human
+```bash
+python cli.py card "Chase Sapphire Preferred"
+python cli.py compare "Amex Gold" "Chase Sapphire Preferred"
+python cli.py roi "Chase Sapphire Preferred" --travel 500 --dining 300 --other 1000
+python cli.py wallet "Amex Platinum" "Chase Freedom Unlimited" "Bilt"
+```
+
+### Agent / piped
+```bash
+python cli.py card "Chase Sapphire Preferred" --json | jq '.result'
+python cli.py recommend "high dining and travel spend" --preferences "no annual fee" --json
+echo "Amex Gold" | python cli.py rates -
+```
+
+### Claude Code skill
+A future `/card-research` skill could shell out to `cli.py` for live data,
+rather than re-implementing the Brave search logic in a prompt.
+
+---
+
+## Out of Scope (for now)
+- Auth / user accounts
+- Persistent caching of search results
+- Card database / local storage
+- Streaming output

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic>=2.0
 python-dotenv
 requests
 watchdog
+typer[all]>=0.12.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,285 @@
+"""
+Tests for cli.py using typer.testing.CliRunner.
+
+All Brave Search calls are mocked — no network required.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli import app
+
+runner = CliRunner()
+
+FAKE_RESULT = "Chase Sapphire Preferred | $95 annual fee | 3x dining, 2x travel"
+
+
+def _mock_search(monkeypatch, return_value: str = FAKE_RESULT):
+    """Patch search_and_format and build_brave_wrapper for all CLI tests."""
+    mock_wrapper = MagicMock()
+    monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+    monkeypatch.setattr("tools.brave_client.build_brave_wrapper", lambda *a, **kw: mock_wrapper)
+    monkeypatch.setattr("tools.brave_client.search_and_format", lambda *a, **kw: return_value)
+    return mock_wrapper
+
+
+# ---------------------------------------------------------------------------
+# card
+# ---------------------------------------------------------------------------
+
+class TestCardCommand:
+    def test_plain_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["card", "Chase Sapphire Preferred"])
+        assert result.exit_code == 0
+        assert FAKE_RESULT in result.output
+
+    def test_json_output_shape(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["card", "Chase Sapphire Preferred", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["command"] == "card"
+        assert data["result"] == FAKE_RESULT
+        assert data["error"] is None
+
+    def test_missing_api_key_exits_code_2(self, monkeypatch):
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        monkeypatch.setattr("cli.load_dotenv", lambda: None)
+        result = runner.invoke(app, ["card", "Chase Sapphire Preferred", "--no-dotenv"])
+        assert result.exit_code == 2
+        err = json.loads(result.output)
+        assert err["ok"] is False
+
+    def test_search_error_exits_code_1(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        monkeypatch.setattr("tools.brave_client.build_brave_wrapper", lambda *a, **kw: MagicMock())
+        monkeypatch.setattr("tools.brave_client.search_and_format", MagicMock(side_effect=Exception("HTTP 429")))
+        result = runner.invoke(app, ["card", "Chase Sapphire Preferred"])
+        assert result.exit_code == 1
+        err = json.loads(result.output)
+        assert err["ok"] is False
+        assert "HTTP 429" in err["error"]
+
+    def test_stdin_input(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["card", "-"], input="Amex Gold\n")
+        assert result.exit_code == 0
+        assert FAKE_RESULT in result.output
+
+
+# ---------------------------------------------------------------------------
+# rates
+# ---------------------------------------------------------------------------
+
+class TestRatesCommand:
+    def test_plain_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["rates", "Amex Gold"])
+        assert result.exit_code == 0
+        assert FAKE_RESULT in result.output
+
+    def test_with_category_flag(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["rates", "Amex Gold", "--category", "dining"])
+        assert result.exit_code == 0
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["rates", "Amex Gold", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "rates"
+        assert data["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# partners
+# ---------------------------------------------------------------------------
+
+class TestPartnersCommand:
+    def test_plain_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["partners", "Capital One Venture X"])
+        assert result.exit_code == 0
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["partners", "Capital One Venture X", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "partners"
+
+
+# ---------------------------------------------------------------------------
+# credits
+# ---------------------------------------------------------------------------
+
+class TestCreditsCommand:
+    def test_plain_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["credits", "Amex Platinum"])
+        assert result.exit_code == 0
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["credits", "Amex Platinum", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "credits"
+
+
+# ---------------------------------------------------------------------------
+# news
+# ---------------------------------------------------------------------------
+
+class TestNewsCommand:
+    def test_uses_freshness_wrapper(self, monkeypatch):
+        """news command should request freshness='pm'."""
+        calls = []
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+
+        def capturing_build(key, freshness=None, **kw):
+            calls.append(freshness)
+            return MagicMock()
+
+        monkeypatch.setattr("tools.brave_client.build_brave_wrapper", capturing_build)
+        monkeypatch.setattr("tools.brave_client.search_and_format", lambda *a, **kw: FAKE_RESULT)
+        result = runner.invoke(app, ["news", "Amex Gold"])
+        assert result.exit_code == 0
+        assert "pm" in calls
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["news", "Amex Gold", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "news"
+
+
+# ---------------------------------------------------------------------------
+# compare
+# ---------------------------------------------------------------------------
+
+class TestCompareCommand:
+    def test_output_contains_both_card_names(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["compare", "Amex Gold", "Chase Sapphire Preferred"])
+        assert result.exit_code == 0
+        assert "Amex Gold" in result.output
+        assert "Chase Sapphire Preferred" in result.output
+
+    def test_calls_search_twice(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        monkeypatch.setattr("tools.brave_client.build_brave_wrapper", lambda *a, **kw: MagicMock())
+        call_count = 0
+
+        def counting_search(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            return FAKE_RESULT
+
+        monkeypatch.setattr("tools.brave_client.search_and_format", counting_search)
+        runner.invoke(app, ["compare", "Amex Gold", "Chase Sapphire Preferred"])
+        assert call_count == 2
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["compare", "Amex Gold", "Chase Sapphire Preferred", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "compare"
+        assert data["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# wallet
+# ---------------------------------------------------------------------------
+
+class TestWalletCommand:
+    def test_multiple_cards(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["wallet", "Amex Platinum", "Chase Freedom Unlimited"])
+        assert result.exit_code == 0
+        assert "Amex Platinum" in result.output
+        assert "Chase Freedom Unlimited" in result.output
+
+    def test_searches_each_card(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        monkeypatch.setattr("tools.brave_client.build_brave_wrapper", lambda *a, **kw: MagicMock())
+        call_count = 0
+
+        def counting_search(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            return FAKE_RESULT
+
+        monkeypatch.setattr("tools.brave_client.search_and_format", counting_search)
+        runner.invoke(app, ["wallet", "Card A", "Card B", "Card C"])
+        assert call_count == 3
+
+    def test_stdin_newline_delimited(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["wallet", "-"], input="Amex Gold\nChase Sapphire Preferred\n")
+        assert result.exit_code == 0
+        assert "Amex Gold" in result.output
+        assert "Chase Sapphire Preferred" in result.output
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["wallet", "Amex Platinum", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "wallet"
+
+
+# ---------------------------------------------------------------------------
+# roi
+# ---------------------------------------------------------------------------
+
+class TestRoiCommand:
+    def test_contains_spend_summary(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, [
+            "roi", "Chase Sapphire Preferred",
+            "--travel", "500", "--dining", "300", "--other", "1000",
+        ])
+        assert result.exit_code == 0
+        assert "6,000" in result.output  # travel * 12
+        assert "3,600" in result.output  # dining * 12
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["roi", "Chase Sapphire Preferred", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "roi"
+        assert data["ok"] is True
+
+    def test_defaults_zero_spend(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["roi", "Chase Sapphire Preferred"])
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# recommend
+# ---------------------------------------------------------------------------
+
+class TestRecommendCommand:
+    def test_plain_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["recommend", "high dining and travel spend"])
+        assert result.exit_code == 0
+
+    def test_with_preferences(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["recommend", "high dining", "--preferences", "no annual fee"])
+        assert result.exit_code == 0
+
+    def test_json_output(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["recommend", "high dining", "--json"])
+        data = json.loads(result.output)
+        assert data["command"] == "recommend"
+
+    def test_stdin_input(self, monkeypatch):
+        _mock_search(monkeypatch)
+        result = runner.invoke(app, ["recommend", "-"], input="heavy travel spender\n")
+        assert result.exit_code == 0


### PR DESCRIPTION
- cli.py: Typer CLI with 9 Brave Search research commands + cards profile management (list/add/remove); supports --json output and stdin piping
- db.py: SQLite persistence layer (fleece.db) replacing user_cards.json; shared between CLI and Streamlit with CRUD + migration helper
- migrate.py: one-shot JSON → SQLite migration script
- pages/my_credit_cards.py: ported from JSON file ops to db.py calls
- .claude/skills/: 9 Claude Code slash command skill files (/fleece-card etc.)
- .agents/skills/fleece/SKILL.md: combined agent skill for OpenClaw/Codex
- install.sh: one-command skill installer for Claude Code and agent platforms
- plan.md: CLI design document
- requirements.txt: add typer[all]>=0.12.0
- .gitignore: exclude fleece.db and user_cards.json.*