### PR TITLE
Wallet portfolio analysis, CLI docs, and mobile-friendly landing pages

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -98,6 +98,47 @@
 
     .nav-links .btn-pill:hover { background: #e6bc00; color: var(--black); }
 
+    /* ── MOBILE NAV ──────────────────────────── */
+    .nav-toggle {
+      display: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 8px;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .nav-toggle span {
+      display: block;
+      width: 22px;
+      height: 2px;
+      background: rgba(255,255,255,0.75);
+      transition: background 0.15s;
+    }
+    .nav-toggle:hover span { background: var(--yellow); }
+
+    @media (max-width: 768px) {
+      nav { padding: 0 1.25rem; position: relative; }
+      .nav-toggle { display: flex; }
+      .nav-links {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 64px;
+        left: 0;
+        right: 0;
+        background: var(--black);
+        border-top: 1px solid #222;
+        padding: 0.5rem 1.25rem 1.25rem;
+        gap: 0;
+        z-index: 99;
+      }
+      .nav-links.open { display: flex; }
+      .nav-links li { padding: 0.6rem 0; border-bottom: 1px solid #1e1e1e; }
+      .nav-links li:last-child { border-bottom: none; padding-top: 0.9rem; }
+      .nav-links .btn-pill { display: inline-block; }
+    }
+
     /* ── PAGE HEADER ──────────────────────────── */
     .page-header {
       background: var(--black);
@@ -459,6 +500,37 @@
     }
 
     .footer-right a:hover { color: var(--yellow); }
+
+    /* ── GLOBAL MOBILE FIXES ─────────────────── */
+    @media (max-width: 768px) {
+      body { font-size: 16px; }
+
+      .page-header { padding: 2.5rem 1.25rem 2rem; }
+
+      .docs-layout { padding: 2rem 1.25rem 3.5rem; }
+
+      .cmd-name { font-size: 1.05rem; }
+      .cmd-block-header { gap: 0.6rem; }
+
+      /* make tables horizontally scrollable */
+      .args-table, .global-opts table {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        white-space: nowrap;
+      }
+      .args-table td, .args-table th { white-space: normal; min-width: 120px; }
+      .args-table td:first-child { white-space: nowrap; }
+
+      .global-opts { padding: 1.25rem; }
+      .global-opts td { white-space: normal; }
+      .global-opts td:first-child { white-space: nowrap; width: auto; min-width: 130px; }
+
+      .example-block { font-size: 0.75rem; padding: 0.85rem 0.9rem; }
+
+      footer { padding: 1.5rem 1.25rem; flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+      .footer-right { flex-wrap: wrap; gap: 1rem; }
+    }
   </style>
 </head>
 <body>
@@ -466,6 +538,9 @@
 <!-- NAV -->
 <nav>
   <a class="nav-logo" href="/">Fleece</a>
+  <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
   <ul class="nav-links">
     <li><a href="/#features">Features</a></li>
     <li><a href="/#workflows">Workflows</a></li>
@@ -990,5 +1065,19 @@
   </div>
 </footer>
 
+<script>
+  var toggle = document.querySelector('.nav-toggle');
+  var links  = document.querySelector('.nav-links');
+  toggle.addEventListener('click', function() {
+    var open = links.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', open);
+  });
+  links.querySelectorAll('a').forEach(function(a) {
+    a.addEventListener('click', function() {
+      links.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+</script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -130,6 +130,47 @@
 
     .nav-links .btn-pill:hover { background: #e6bc00; color: var(--black); }
 
+    /* ── MOBILE NAV ──────────────────────────── */
+    .nav-toggle {
+      display: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 8px;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .nav-toggle span {
+      display: block;
+      width: 22px;
+      height: 2px;
+      background: rgba(255,255,255,0.75);
+      transition: background 0.15s;
+    }
+    .nav-toggle:hover span { background: var(--yellow); }
+
+    @media (max-width: 768px) {
+      nav { padding: 0 1.25rem; position: relative; }
+      .nav-toggle { display: flex; }
+      .nav-links {
+        display: none;
+        flex-direction: column;
+        position: absolute;
+        top: 64px;
+        left: 0;
+        right: 0;
+        background: var(--black);
+        border-top: 1px solid #222;
+        padding: 0.5rem 1.25rem 1.25rem;
+        gap: 0;
+        z-index: 99;
+      }
+      .nav-links.open { display: flex; }
+      .nav-links li { padding: 0.6rem 0; border-bottom: 1px solid #1e1e1e; }
+      .nav-links li:last-child { border-bottom: none; padding-top: 0.9rem; }
+      .nav-links .btn-pill { display: inline-block; }
+    }
+
     /* ── HERO ─────────────────────────────────── */
     .hero {
       background: var(--black);
@@ -494,6 +535,30 @@
     }
 
     .footer-right a:hover { color: var(--yellow); }
+
+    /* ── GLOBAL MOBILE FIXES ─────────────────── */
+    @media (max-width: 768px) {
+      body { font-size: 16px; }
+
+      .hero { padding: 4rem 1.25rem 3rem; }
+      .hero h1 { font-size: 2.2rem; }
+      .hero p { font-size: 0.95rem; }
+      .hero-install-box { padding: 1.75rem 1.25rem; }
+
+      .cards-section { padding: 3.5rem 1.25rem; }
+      .announcement { padding: 3.5rem 1.25rem; }
+      .contact-section { padding: 3.5rem 1.25rem; }
+
+      /* stats strip */
+      div[style*="gap:3rem"] { gap: 1.5rem !important; padding: 1.5rem 1.25rem !important; }
+
+      /* cmd list */
+      .cmd-row { flex-direction: column; gap: 0.2rem; }
+      .cmd-name { min-width: unset; }
+
+      footer { padding: 1.5rem 1.25rem; flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+      .footer-right { flex-wrap: wrap; gap: 1rem; }
+    }
   </style>
 </head>
 <body>
@@ -501,6 +566,9 @@
 <!-- NAV -->
 <nav>
   <a class="nav-logo" href="#">Fleece</a>
+  <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
   <ul class="nav-links">
     <li><a href="#features">Features</a></li>
     <li><a href="#workflows">Workflows</a></li>
@@ -823,5 +891,19 @@
   </div>
 </footer>
 
+<script>
+  var toggle = document.querySelector('.nav-toggle');
+  var links  = document.querySelector('.nav-links');
+  toggle.addEventListener('click', function() {
+    var open = links.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', open);
+  });
+  links.querySelectorAll('a').forEach(function(a) {
+    a.addEventListener('click', function() {
+      links.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`fleece wallet` restored as portfolio analysis** — reads saved cards from the local DB, fetches live earning-rate data per card via Brave Search, and returns structured `{cards, research, profile, analysis_prompt}` JSON so an agent can compute a real coverage map, overlaps, and gaps (fixes the "snippet-dump" issue raised in clawdbot feedback)
- **`fleece cards`** remains the offline CRUD interface (list / add / remove) for managing the wallet
- **`docs/commands.html`** — new full CLI reference page at `getfleece.io/commands` covering all 13+ commands with arguments, options, and examples, matching the existing site design
- **`--help` text improved** across all CLI commands — every command now includes a description, API key requirements, and concrete usage examples
- **Mobile-friendly** — both `index.html` and `commands.html` now have a hamburger nav, reduced mobile padding, horizontally-scrollable tables, and stacked layouts on narrow screens
- **SKILL.md** (both copies) updated to v1.6.0 with accurate wallet behavior, JSON output format, and cards subcommand examples

## Test plan

- [ ] `fleece wallet --json` returns `{command, cards, research, profile, analysis_prompt, ok}`
- [ ] `fleece wallet` (plain text) prints per-card research snippets followed by a labelled analysis prompt
- [ ] `fleece cards list` still works offline with no API key
- [ ] `fleece <command> --help` shows examples for every command
- [ ] `getfleece.io/commands` renders correctly on desktop and mobile
- [ ] Nav hamburger opens/closes on mobile for both pages
- [ ] Args tables scroll horizontally on narrow screens

https://claude.ai/code/session_01GSC92LAZutD3kaVRb2YG5b
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSC92LAZutD3kaVRb2YG5b)_