### PR TITLE
Enable all device orientations for iOS app

### DIFF
--- a/ios/FleeceApp/Info.plist
+++ b/ios/FleeceApp/Info.plist
@@ -41,6 +41,16 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Updated the iOS app configuration to support all device orientations (portrait, portrait upside-down, landscape left, and landscape right) for both iPhone and iPad devices.

## Changes
- **iPhone orientations**: Added support for portrait upside-down, landscape left, and landscape right (in addition to existing portrait support)
- **iPad orientations**: Added new `UISupportedInterfaceOrientations~ipad` key with full support for all four orientations

## Details
Previously, the app was locked to portrait orientation only. This change allows the Fleece iOS app to rotate and adapt to all standard device orientations, improving usability when users rotate their devices and providing a better experience on iPad where landscape orientation is commonly used.

https://claude.ai/code/session_01EENduAz5vdHgyyZKe76sjN