### PR TITLE
Add US Credit Card Guide to search sources

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -410,7 +410,7 @@ def recommend(
     saved_ctx = _db.profile_as_context(cards=_db.get_card_names())
     ctx = f"{saved_ctx} | " if saved_ctx else ""
 
-    query = f"best credit cards {ctx}{profile} {pref}US 2025 site:nerdwallet.com OR site:thepointsguy.com OR site:doctorofcredit.com"
+    query = f"best credit cards {ctx}{profile} {pref}US 2025 site:nerdwallet.com OR site:thepointsguy.com OR site:doctorofcredit.com OR site:uscreditcardguide.com"
     _run_search(_get_wrapper(key), query, "recommend", as_json)
 
 

--- a/tools/brave_client.py
+++ b/tools/brave_client.py
@@ -16,6 +16,7 @@ PRIORITY_SITES = [
     "doctorofcredit.com",
     "bankrate.com",
     "onemileatatime.com",
+    "uscreditcardguide.com",
 ]
 
 

--- a/tools/credit_card_tools.py
+++ b/tools/credit_card_tools.py
@@ -233,7 +233,7 @@ def build_tools(brave_api_key: str) -> list[BaseTool]:
         pref_clause = f"{preferences} " if preferences else ""
         query = (
             f"best credit cards {spending_profile} {pref_clause}US 2025 "
-            f"site:nerdwallet.com OR site:thepointsguy.com OR site:doctorofcredit.com"
+            f"site:nerdwallet.com OR site:thepointsguy.com OR site:doctorofcredit.com OR site:uscreditcardguide.com"
         )
         return search_and_format(wrapper, query)
 


### PR DESCRIPTION
## Summary
Expands the credit card research sources by adding US Credit Card Guide (`uscreditcardguide.com`) to the search queries used by the `recommend` command and the chatbot's card recommendation tool.

## Changes
- **cli.py**: Added `site:uscreditcardguide.com` to the search query in the `recommend()` command
- **tools/credit_card_tools.py**: Added `site:uscreditcardguide.com` to the search query in `_recommend_cards_for_profile()`
- **tools/brave_client.py**: Added `"uscreditcardguide.com"` to the `TRUSTED_SOURCES` list for source validation

## Details
This change broadens the research sources for card recommendations from three to four trusted domains:
- nerdwallet.com
- thepointsguy.com
- doctorofcredit.com
- uscreditcardguide.com (new)

The addition is consistent across both the CLI and chatbot surfaces, ensuring unified behavior when users request card recommendations via either interface.

https://claude.ai/code/session_01GSC92LAZutD3kaVRb2YG5b