### PR TITLE
Add annual fee renewal tracker, new cards, and WidgetKit extension

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -715,6 +715,7 @@ def cards_list(
 def cards_add(
     name:       Annotated[str, typer.Argument(help="Card name to add.")],
     annual_fee: Annotated[str, typer.Option("--fee", help="Annual fee (e.g. $95).")] = "$0",
+    fee_date:   Annotated[Optional[str], typer.Option("--fee-date", help="Annual fee renewal date as MM-DD (e.g. 01-15).")] = None,
     as_json:    JsonOpt = False,
 ):
     """Add a card to your wallet.
@@ -723,7 +724,7 @@ def cards_add(
     fleece recommend, and fleece roi.
 
     Examples:
-      fleece cards add "Chase Sapphire Preferred" --fee "$95"
+      fleece cards add "Chase Sapphire Preferred" --fee "$95" --fee-date 03-20
       fleece cards add "Amex Gold" --fee "$250"
       fleece cards add "Citi Double Cash"
     """
@@ -733,6 +734,7 @@ def cards_add(
         "name": name,
         "annual_fee": annual_fee,
         "date_added": datetime.date.today().isoformat(),
+        "fee_date": fee_date or "",
     }
     try:
         db.add_card(new_card)
@@ -774,6 +776,108 @@ def cards_remove(
         typer.echo(json.dumps({"command": "cards remove", "removed": removed["name"], "ok": True, "error": None}))
     else:
         typer.echo(f'Removed "{removed["name"]}" from your profile. ({remaining} card(s) remaining)')
+
+
+@cards_app.command("renewal")
+def cards_renewal(
+    days:    Annotated[int,  typer.Option("--days", "-d", help="Only show renewals within N days (0 = all).")] = 0,
+    as_json: JsonOpt = False,
+):
+    """Show upcoming annual fee renewal schedule, sorted by days remaining.
+
+    Cards without a fee date set are listed separately at the bottom.
+    Use --days N to narrow the view (e.g. --days 60 for next two months).
+    Set a fee date with: fleece cards fee-date "<card>" MM-DD
+
+    Examples:
+      fleece cards renewal
+      fleece cards renewal --days 90
+      fleece cards renewal --json
+    """
+    import db
+    all_cards = db.get_cards()
+    if not all_cards:
+        if as_json:
+            typer.echo(json.dumps({"command": "renewal", "schedule": [], "no_date_set": [], "ok": True, "error": None}))
+        else:
+            typer.echo("No cards in wallet. Add one with: fleece cards add \"<card name>\"")
+        return
+
+    full_schedule = db.get_renewal_schedule()
+    schedule = [c for c in full_schedule if c["days_until"] <= days] if days > 0 else full_schedule
+    no_date  = [c for c in all_cards if not c.get("fee_date")]
+
+    if as_json:
+        typer.echo(json.dumps({
+            "command":     "renewal",
+            "schedule":    schedule,
+            "no_date_set": [c["name"] for c in no_date],
+            "ok":          True,
+            "error":       None,
+        }))
+        return
+
+    if schedule:
+        typer.echo("\nUpcoming annual fee renewals:\n")
+        typer.echo(f"  {'Date':<12}  {'Days':>6}  {'Card':<40}  Fee")
+        typer.echo("  " + "-" * 72)
+        for card in schedule:
+            days_str = "TODAY" if card["days_until"] == 0 else f"{card['days_until']}d"
+            fee_str  = card.get("annual_fee", "N/A")
+            typer.echo(f"  {card['next_renewal']:<12}  {days_str:>6}  {card['name']:<40}  {fee_str}")
+    else:
+        typer.echo("No upcoming renewals found.")
+
+    if no_date:
+        typer.echo(f"\n{len(no_date)} card(s) without a fee date:")
+        for c in no_date:
+            typer.echo(f"  - {c['name']}")
+        typer.echo("\n  Set one with: fleece cards fee-date \"<card>\" MM-DD")
+
+
+@cards_app.command("fee-date")
+def cards_fee_date(
+    name:    Annotated[str, typer.Argument(help="Card name (partial match OK).")],
+    date:    Annotated[str, typer.Argument(help="Annual fee renewal date as MM-DD (e.g. 01-15 for Jan 15).")],
+    as_json: JsonOpt = False,
+):
+    """Set the annual fee renewal date for a card (MM-DD format).
+
+    The date repeats each year. Use 'fleece cards renewal' to see the full schedule.
+
+    Examples:
+      fleece cards fee-date "Amex Gold" 01-15
+      fleece cards fee-date "Chase Sapphire" 03-20
+      fleece cards fee-date "sapphire" 06-01 --json
+    """
+    import datetime
+    import re
+    import db
+
+    if not re.match(r"^\d{2}-\d{2}$", date):
+        _error_exit("Date must be MM-DD format (e.g. 01-15 for Jan 15).", code=1)
+    try:
+        month, day = map(int, date.split("-"))
+        datetime.date(2024, month, day)
+    except ValueError:
+        _error_exit(f'Invalid date "{date}". Use MM-DD format (e.g. 01-15).', code=1)
+
+    all_cards = db.get_cards()
+    matches   = [c for c in all_cards if name.lower() in c["name"].lower()]
+    if not matches:
+        _error_exit(f'No card matching "{name}". Add it with: fleece cards add "<name>"', code=1)
+    if len(matches) > 1:
+        names = ", ".join(f'"{c["name"]}"' for c in matches)
+        _error_exit(f"Ambiguous match — found {names}. Be more specific.", code=1)
+
+    card = matches[0]
+    db.update_card(card["name"], {"fee_date": date})
+
+    if as_json:
+        typer.echo(json.dumps({"command": "fee-date", "card": card["name"], "fee_date": date, "ok": True, "error": None}))
+    else:
+        typer.echo(f'Set fee renewal date for "{card["name"]}" to {date}.')
+        typer.echo("Run 'fleece cards renewal' to see your full schedule.")
 
 
 # ---------------------------------------------------------------------------

--- a/db.py
+++ b/db.py
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS cards (
     rewards      TEXT    NOT NULL DEFAULT '',
     expiration   TEXT    NOT NULL DEFAULT '',
     image_url    TEXT    NOT NULL DEFAULT '',
-    date_added   TEXT    NOT NULL DEFAULT (date('now'))
+    date_added   TEXT    NOT NULL DEFAULT (date('now')),
+    fee_date     TEXT    NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS profile (
     key   TEXT PRIMARY KEY,
@@ -44,7 +45,7 @@ PROFILE_FIELDS = {
 }
 
 _COLUMNS = ("id", "name", "last_four", "annual_fee", "credit_limit",
-            "rewards", "expiration", "image_url", "date_added")
+            "rewards", "expiration", "image_url", "date_added", "fee_date")
 
 
 @contextmanager
@@ -62,6 +63,9 @@ def init_db() -> None:
     """Create tables if they don't exist. Safe to call on every startup."""
     with _conn() as con:
         con.executescript(_SCHEMA)
+        cols = {row[1] for row in con.execute("PRAGMA table_info(cards)")}
+        if "fee_date" not in cols:
+            con.execute("ALTER TABLE cards ADD COLUMN fee_date TEXT NOT NULL DEFAULT ''")
 
 
 def _row_to_dict(row: sqlite3.Row) -> dict:
@@ -108,9 +112,9 @@ def add_card(card: dict) -> None:
             con.execute(
                 """
                 INSERT INTO cards (name, last_four, annual_fee, credit_limit,
-                                   rewards, expiration, image_url, date_added)
+                                   rewards, expiration, image_url, date_added, fee_date)
                 VALUES (:name, :last_four, :annual_fee, :credit_limit,
-                        :rewards, :expiration, :image_url, :date_added)
+                        :rewards, :expiration, :image_url, :date_added, :fee_date)
                 """,
                 {
                     "name":         card.get("name", ""),
@@ -121,6 +125,7 @@ def add_card(card: dict) -> None:
                     "expiration":   card.get("expiration", ""),
                     "image_url":    card.get("image_url", ""),
                     "date_added":   card.get("date_added", ""),
+                    "fee_date":     card.get("fee_date", ""),
                 },
             )
         except sqlite3.IntegrityError:
@@ -216,6 +221,39 @@ def profile_as_context(cards: list[str] | None = None) -> str:
         parts.append(f"Current cards: {', '.join(cards)}")
 
     return " | ".join(parts) if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# Renewal schedule
+# ---------------------------------------------------------------------------
+
+def get_renewal_schedule() -> list[dict]:
+    """Return cards with fee_date set, sorted by days until next annual fee renewal.
+
+    Each dict includes the card's fields plus:
+      next_renewal  — ISO date of the next renewal (this year or next)
+      days_until    — integer days from today
+    """
+    import datetime
+    today = datetime.date.today()
+    schedule = []
+    for card in get_cards():
+        fee_date = card.get("fee_date", "")
+        if not fee_date:
+            continue
+        try:
+            month, day = map(int, fee_date.split("-"))
+            next_renewal = datetime.date(today.year, month, day)
+            if next_renewal < today:
+                next_renewal = datetime.date(today.year + 1, month, day)
+            schedule.append({
+                **card,
+                "next_renewal": next_renewal.isoformat(),
+                "days_until":   (next_renewal - today).days,
+            })
+        except (ValueError, AttributeError):
+            continue
+    return sorted(schedule, key=lambda x: x["days_until"])
 
 
 # ---------------------------------------------------------------------------

--- a/ios/FleeceApp.xcodeproj/project.pbxproj
+++ b/ios/FleeceApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		26EAE12A2BBC945D4C550890 /* WalletDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 421B143C13EC925B409964E3 /* WalletDetectionService.swift */; };
 		28DD764E157DE5E0E7F784E0 /* FleeceWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3B604758D7A904F6FE1FE122 /* FleeceWidget.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		295016FCF109574F2F37A284 /* AskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD936D99063C9DA8B3B55DE /* AskView.swift */; };
+		30BC3514C0AD635B1B2DA38D /* FeeCalendarWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C38D95CDE2B2F0C462BDA /* FeeCalendarWidgetData.swift */; };
 		3B87CF9F384D042593119BAC /* CardDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84525AB21DF76636B0AFC0B5 /* CardDatabase.swift */; };
 		405B50C34B02F69B2AC1F780 /* FleeceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1826DC93917C0B0B3EF296 /* FleeceApp.swift */; };
 		4C92A100EC8FB9B4313F3B34 /* FleeceWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D481497856B9BD1BA693A2 /* FleeceWidgetData.swift */; };
@@ -27,6 +28,7 @@
 		A397AA02E9CF09021A4C8B02 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703BF2836D6238B002869015 /* AppState.swift */; };
 		AFE04A07880B524D9183945D /* NearbyPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F187A4598F6D209993AC22C /* NearbyPlace.swift */; };
 		B57F8DD66FDD8C0711E27D3B /* Recommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14D8916A38C72FE58C7F85A /* Recommendation.swift */; };
+		B76BFF06AFF548EC998D10D7 /* FeeCalendarWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C38D95CDE2B2F0C462BDA /* FeeCalendarWidgetData.swift */; };
 		B9B17402C400AC33300E7E97 /* CardExplanationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7682486A135077BAE1B30D71 /* CardExplanationService.swift */; };
 		BB70CF6EDE3084FE58378024 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0F4AC23D675E1415DB4B6B /* NotificationManager.swift */; };
 		C0A5988803B897F2948A8932 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1574A163081F73D8004D7C8 /* SettingsView.swift */; };
@@ -73,6 +75,7 @@
 		2B940D56E7DAE6767D1B5952 /* PlacesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesService.swift; sourceTree = "<group>"; };
 		37ECE2F59AB406D9AB432C6E /* FleeceWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleeceWidget.swift; sourceTree = "<group>"; };
 		3B604758D7A904F6FE1FE122 /* FleeceWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = FleeceWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F1C38D95CDE2B2F0C462BDA /* FeeCalendarWidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeCalendarWidgetData.swift; sourceTree = "<group>"; };
 		421B143C13EC925B409964E3 /* WalletDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDetectionService.swift; sourceTree = "<group>"; };
 		45FE76A687A76480310D39FA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		54D481497856B9BD1BA693A2 /* FleeceWidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleeceWidgetData.swift; sourceTree = "<group>"; };
@@ -140,6 +143,7 @@
 			children = (
 				B3D19C4B82DDA34743959D95 /* ChatMessage.swift */,
 				A529343561E11E145A0547A4 /* CreditCard.swift */,
+				3F1C38D95CDE2B2F0C462BDA /* FeeCalendarWidgetData.swift */,
 				54D481497856B9BD1BA693A2 /* FleeceWidgetData.swift */,
 				BD349E07A432AB028C10E2FD /* MCCCategory.swift */,
 				7F187A4598F6D209993AC22C /* NearbyPlace.swift */,
@@ -315,6 +319,7 @@
 				F124CDAD193AB5EDD27D24D7 /* Config.swift in Sources */,
 				908728529B78523F2F3A9BA9 /* ContentView.swift in Sources */,
 				1C421BBC5ADB84E3F2B3C903 /* CreditCard.swift in Sources */,
+				B76BFF06AFF548EC998D10D7 /* FeeCalendarWidgetData.swift in Sources */,
 				405B50C34B02F69B2AC1F780 /* FleeceApp.swift in Sources */,
 				4C92A100EC8FB9B4313F3B34 /* FleeceWidgetData.swift in Sources */,
 				CE6DE7FB4B5B30A91ECE5549 /* HomeView.swift in Sources */,
@@ -337,6 +342,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				30BC3514C0AD635B1B2DA38D /* FeeCalendarWidgetData.swift in Sources */,
 				614CD32EA980D6B2D6D4971B /* FleeceWidget.swift in Sources */,
 				52115954F67280B10F178ACF /* FleeceWidgetData.swift in Sources */,
 			);

--- a/ios/FleeceApp/AppState.swift
+++ b/ios/FleeceApp/AppState.swift
@@ -28,6 +28,9 @@ final class AppState: ObservableObject {
     @Published var detectedNetworks: Set<PKPaymentNetwork> = []
     @Published var suggestedCards: [CreditCard] = []
 
+    // Annual fee renewal dates — keyed by card UUID string
+    @Published var renewalDates: [String: Date] = [:]
+
     enum Tab: Hashable { case home, wallet, ask, settings }
 
     private let placesService = PlacesService()
@@ -36,6 +39,7 @@ final class AppState: ObservableObject {
 
     init() {
         cards = loadWallet()
+        renewalDates = loadRenewalDates()
         runWalletDetection()
     }
 
@@ -159,6 +163,31 @@ final class AppState: ObservableObject {
             c.isInWallet = walletIDs.contains(card.id.uuidString)
             return c
         }
+    }
+
+    // MARK: - Renewal dates
+
+    func renewalDate(for card: CreditCard) -> Date? {
+        renewalDates[card.id.uuidString]
+    }
+
+    func setRenewalDate(_ date: Date?, for card: CreditCard) {
+        if let date {
+            renewalDates[card.id.uuidString] = date
+        } else {
+            renewalDates.removeValue(forKey: card.id.uuidString)
+        }
+        persistRenewalDates()
+    }
+
+    private func persistRenewalDates() {
+        let raw = renewalDates.mapValues { $0.timeIntervalSince1970 }
+        UserDefaults.standard.set(raw, forKey: "fleeceRenewalDates")
+    }
+
+    private func loadRenewalDates() -> [String: Date] {
+        let raw = UserDefaults.standard.dictionary(forKey: "fleeceRenewalDates") as? [String: Double] ?? [:]
+        return raw.mapValues { Date(timeIntervalSince1970: $0) }
     }
 
     // MARK: - Util

--- a/ios/FleeceApp/AppState.swift
+++ b/ios/FleeceApp/AppState.swift
@@ -132,6 +132,7 @@ final class AppState: ObservableObject {
             }
         }
         runWalletDetection()
+        saveFeeCalendarWidgetData()
     }
 
     private func saveWidgetData(recommendation: CardRecommendation) {
@@ -178,11 +179,39 @@ final class AppState: ObservableObject {
             renewalDates.removeValue(forKey: card.id.uuidString)
         }
         persistRenewalDates()
+        saveFeeCalendarWidgetData()
     }
 
     private func persistRenewalDates() {
         let raw = renewalDates.mapValues { $0.timeIntervalSince1970 }
         UserDefaults.standard.set(raw, forKey: "fleeceRenewalDates")
+    }
+
+    func saveFeeCalendarWidgetData() {
+        let cal   = Calendar.current
+        let today = cal.startOfDay(for: .now)
+        let items: [FeeCalendarWidgetData.RenewalItem] = cards
+            .filter { $0.isInWallet && $0.annualFee > 0 }
+            .compactMap { card in
+                guard let date = renewalDates[card.id.uuidString] else { return nil }
+                var next = cal.startOfDay(for: date)
+                while next < today {
+                    next = cal.date(byAdding: .year, value: 1, to: next)!
+                }
+                let days = cal.dateComponents([.day], from: today, to: next).day ?? 0
+                return FeeCalendarWidgetData.RenewalItem(
+                    cardName:        card.name,
+                    cardColor:       card.cardColor,
+                    textColor:       card.textColor,
+                    annualFee:       card.annualFee,
+                    nextRenewalDate: next,
+                    daysUntil:       days
+                )
+            }
+            .sorted { $0.daysUntil < $1.daysUntil }
+
+        FeeCalendarWidgetData(renewals: items, updatedAt: .now).save()
+        WidgetCenter.shared.reloadTimelines(ofKind: "FeeCalendarWidget")
     }
 
     private func loadRenewalDates() -> [String: Date] {

--- a/ios/FleeceApp/Models/FeeCalendarWidgetData.swift
+++ b/ios/FleeceApp/Models/FeeCalendarWidgetData.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// Shared model written by the main app, read by the fee calendar widget extension.
+// Both targets include this file; only Foundation is imported so there are no target conflicts.
+struct FeeCalendarWidgetData: Codable, Sendable {
+    struct RenewalItem: Codable, Sendable {
+        let cardName: String
+        let cardColor: String       // hex e.g. "#B8860B"
+        let textColor: String       // hex e.g. "#FFFFFF"
+        let annualFee: Int
+        let nextRenewalDate: Date
+        let daysUntil: Int
+    }
+
+    let renewals: [RenewalItem]     // sorted ascending by daysUntil
+    let updatedAt: Date
+
+    static let appGroupID  = "group.io.getfleece.app"
+    static let defaultsKey = "fleeceFeeCalendarData"
+
+    static func load() -> FeeCalendarWidgetData? {
+        guard let defaults = UserDefaults(suiteName: appGroupID),
+              let data = defaults.data(forKey: defaultsKey) else { return nil }
+        return try? JSONDecoder().decode(FeeCalendarWidgetData.self, from: data)
+    }
+
+    func save() {
+        guard let defaults = UserDefaults(suiteName: FeeCalendarWidgetData.appGroupID),
+              let data = try? JSONEncoder().encode(self) else { return }
+        defaults.set(data, forKey: FeeCalendarWidgetData.defaultsKey)
+    }
+}

--- a/ios/FleeceApp/Services/CardDatabase.swift
+++ b/ios/FleeceApp/Services/CardDatabase.swift
@@ -280,6 +280,25 @@ enum CardDatabase {
             isInWallet: false
         ),
 
+        CreditCard(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000017")!,
+            name: "Discover it Cash Back",
+            issuer: "Discover",
+            annualFee: 0,
+            pointsProgram: "Cash Back",
+            pointValueCents: 1.0,
+            categoryMultipliers: [
+                MCCCategory.gas.rawValue:           5,
+                MCCCategory.groceries.rawValue:     5,
+                MCCCategory.dining.rawValue:        5,
+                MCCCategory.drugstore.rawValue:     5,
+            ],
+            baseMultiplier: 1,
+            cardColor: "#F76B1C",
+            textColor: "#FFFFFF",
+            isInWallet: false
+        ),
+
         // MARK: - Business Cards
 
         CreditCard(

--- a/ios/FleeceApp/Services/CardDatabase.swift
+++ b/ios/FleeceApp/Services/CardDatabase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// Hard-coded card data for 9 major US cards.
+// Hard-coded card data for major US cards.
 // Multipliers reflect published category bonuses as of mid-2025.
 // Point values are conservative mid-market estimates (TPG/NerdWallet baseline).
 enum CardDatabase {
@@ -249,6 +249,33 @@ enum CardDatabase {
             ],
             baseMultiplier: 1,
             cardColor: "#C0392B",
+            textColor: "#FFFFFF",
+            isInWallet: false
+        ),
+
+        CreditCard(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000015")!,
+            name: "Robinhood Gold Card",
+            issuer: "Robinhood",
+            annualFee: 50,
+            pointsProgram: "Cash Back",
+            pointValueCents: 1.0,
+            categoryMultipliers: [:],
+            baseMultiplier: 3,
+            cardColor: "#C8A400",
+            textColor: "#000000",
+            isInWallet: false
+        ),
+        CreditCard(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000016")!,
+            name: "Active Cash",
+            issuer: "Wells Fargo",
+            annualFee: 0,
+            pointsProgram: "Cash Back",
+            pointValueCents: 1.0,
+            categoryMultipliers: [:],
+            baseMultiplier: 2,
+            cardColor: "#CC0000",
             textColor: "#FFFFFF",
             isInWallet: false
         ),

--- a/ios/FleeceApp/Views/WalletView.swift
+++ b/ios/FleeceApp/Views/WalletView.swift
@@ -22,6 +22,16 @@ struct WalletView: View {
                     }
                 }
 
+                // Annual fee renewal tracker — only for wallet cards with a fee
+                let feeCards = walletCards.filter { $0.annualFee > 0 }
+                if !feeCards.isEmpty {
+                    Section("Annual Fee Calendar") {
+                        ForEach(feeCards) { card in
+                            RenewalRowView(card: card)
+                        }
+                    }
+                }
+
                 // Suggested cards (detected via Apple Wallet networks) shown first,
                 // then remaining cards — no detection UI exposed to the user.
                 let addSection = appState.suggestedCards + availableCards
@@ -35,6 +45,71 @@ struct WalletView: View {
             }
             .listStyle(.insetGrouped)
             .navigationTitle("Wallet")
+        }
+    }
+}
+
+// MARK: - Renewal Row
+
+struct RenewalRowView: View {
+    let card: CreditCard
+    @EnvironmentObject var appState: AppState
+    @State private var pickerDate: Date = .now
+    @State private var hasDate: Bool = false
+
+    private var daysUntil: Int {
+        guard hasDate else { return 0 }
+        let cal   = Calendar.current
+        let today = cal.startOfDay(for: .now)
+        var next  = cal.startOfDay(for: pickerDate)
+        while next < today {
+            next = cal.date(byAdding: .year, value: 1, to: next)!
+        }
+        return cal.dateComponents([.day], from: today, to: next).day ?? 0
+    }
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(card.name)
+                    .font(.subheadline).fontWeight(.medium)
+                if hasDate {
+                    let d = daysUntil
+                    Text(d == 0 ? "Due today" : "\(d) days away")
+                        .font(.caption)
+                        .foregroundStyle(d <= 30 ? .orange : .secondary)
+                } else {
+                    Text("Tap to set renewal date")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if hasDate {
+                DatePicker("", selection: $pickerDate, displayedComponents: .date)
+                    .labelsHidden()
+                    .onChange(of: pickerDate) { _, date in
+                        appState.setRenewalDate(date, for: card)
+                    }
+            } else {
+                Button("Set") {
+                    pickerDate = .now
+                    hasDate    = true
+                    appState.setRenewalDate(.now, for: card)
+                }
+                .font(.caption)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(.vertical, 2)
+        .onAppear {
+            if let saved = appState.renewalDate(for: card) {
+                pickerDate = saved
+                hasDate    = true
+            }
         }
     }
 }

--- a/ios/FleeceWidget/FleeceWidget.swift
+++ b/ios/FleeceWidget/FleeceWidget.swift
@@ -245,6 +245,7 @@ struct FleeceWidget: Widget {
 struct FleeceWidgetBundle: WidgetBundle {
     var body: some Widget {
         FleeceWidget()
+        FeeCalendarWidget()
     }
 }
 
@@ -261,4 +262,189 @@ private extension Color {
             blue:  Double( val        & 0xFF) / 255
         )
     }
+}
+
+// ===========================================================================
+// MARK: - Fee Calendar Widget
+// ===========================================================================
+
+// MARK: Provider
+
+struct FeeCalendarTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> FeeCalendarEntry {
+        .placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (FeeCalendarEntry) -> Void) {
+        completion(entry(from: FeeCalendarWidgetData.load()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<FeeCalendarEntry>) -> Void) {
+        let e = entry(from: FeeCalendarWidgetData.load())
+        // Refresh at midnight so "days away" counts stay accurate
+        let midnight = Calendar.current.startOfDay(
+            for: Calendar.current.date(byAdding: .day, value: 1, to: .now)!
+        )
+        completion(Timeline(entries: [e], policy: .after(midnight)))
+    }
+
+    private func entry(from data: FeeCalendarWidgetData?) -> FeeCalendarEntry {
+        FeeCalendarEntry(date: .now, renewals: data?.renewals ?? [])
+    }
+}
+
+// MARK: Entry
+
+struct FeeCalendarEntry: TimelineEntry {
+    let date: Date
+    let renewals: [FeeCalendarWidgetData.RenewalItem]
+
+    static let placeholder = FeeCalendarEntry(date: .now, renewals: [
+        .init(cardName: "Sapphire Reserve", cardColor: "#1A1A2E", textColor: "#FFFFFF",
+              annualFee: 550, nextRenewalDate: .now.addingTimeInterval(86400 * 23), daysUntil: 23),
+        .init(cardName: "Amex Gold",        cardColor: "#B8860B", textColor: "#FFFFFF",
+              annualFee: 325, nextRenewalDate: .now.addingTimeInterval(86400 * 71), daysUntil: 71),
+    ])
+}
+
+// MARK: Small view — next single renewal
+
+struct FeeCalendarSmallView: View {
+    let entry: FeeCalendarEntry
+
+    var body: some View {
+        if let next = entry.renewals.first {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text("💳")
+                        .font(.title3)
+                    Spacer()
+                    Text("$\(next.annualFee)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(next.cardName)
+                    .font(.headline)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+                Spacer(minLength: 4)
+                Text(next.daysUntil == 0 ? "Due today" : "\(next.daysUntil) days")
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(feeUrgencyColor(days: next.daysUntil))
+                Text("annual fee")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(14)
+            .widgetURL(URL(string: "fleece://wallet"))
+        } else {
+            VStack(spacing: 8) {
+                Text("💳")
+                    .font(.largeTitle)
+                Text("No renewal\ndates set")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .widgetURL(URL(string: "fleece://wallet"))
+        }
+    }
+}
+
+// MARK: Medium view — up to 3 renewals
+
+struct FeeCalendarMediumView: View {
+    let entry: FeeCalendarEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Annual Fee Calendar")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .kerning(0.4)
+                .padding(.bottom, 8)
+
+            if entry.renewals.isEmpty {
+                Spacer()
+                Text("Open Fleece → Wallet to set renewal dates.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                ForEach(Array(entry.renewals.prefix(3).enumerated()), id: \.offset) { index, item in
+                    HStack(spacing: 10) {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color(hex: item.cardColor) ?? .gray)
+                            .frame(width: 6, height: 32)
+
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(item.cardName)
+                                .font(.subheadline.weight(.medium))
+                                .lineLimit(1)
+                            Text("$\(item.annualFee)/yr")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        VStack(alignment: .trailing, spacing: 1) {
+                            Text(item.daysUntil == 0 ? "Today" : "\(item.daysUntil)d")
+                                .font(.subheadline.weight(.bold))
+                                .foregroundStyle(feeUrgencyColor(days: item.daysUntil))
+                            Text(item.nextRenewalDate, format: .dateTime.month(.abbreviated).day())
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    if index < min(entry.renewals.count, 3) - 1 {
+                        Divider().padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .widgetURL(URL(string: "fleece://wallet"))
+    }
+}
+
+// MARK: Router
+
+struct FeeCalendarWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: FeeCalendarEntry
+
+    var body: some View {
+        switch family {
+        case .systemMedium:
+            FeeCalendarMediumView(entry: entry)
+        default:
+            FeeCalendarSmallView(entry: entry)
+        }
+    }
+}
+
+// MARK: Widget definition
+
+struct FeeCalendarWidget: Widget {
+    let kind = "FeeCalendarWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: FeeCalendarTimelineProvider()) { entry in
+            FeeCalendarWidgetEntryView(entry: entry)
+                .containerBackground(.background, for: .widget)
+        }
+        .configurationDisplayName("Annual Fee Calendar")
+        .description("Tracks upcoming credit card annual fee renewal dates.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+private func feeUrgencyColor(days: Int) -> Color {
+    if days <= 7  { return .red }
+    if days <= 30 { return .orange }
+    return .primary
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -73,6 +73,7 @@ targets:
     sources:
       - path: FleeceWidget
       - path: FleeceApp/Models/FleeceWidgetData.swift
+      - path: FleeceApp/Models/FeeCalendarWidgetData.swift
     info:
       path: FleeceWidget/Info.plist
       properties:

--- a/tests/test_renewal.py
+++ b/tests/test_renewal.py
@@ -1,0 +1,245 @@
+"""
+Tests for the annual fee renewal tracker:
+  - db.get_renewal_schedule()
+  - CLI: fleece cards fee-date
+  - CLI: fleece cards renewal
+  - CLI: fleece cards add --fee-date
+"""
+import datetime
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cli import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixture: isolated temp database
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def temp_db(tmp_path, monkeypatch):
+    """Point db.DB_PATH at a fresh temp file for each test."""
+    import db
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test_fleece.db")
+    db.init_db()
+    return tmp_path / "test_fleece.db"
+
+
+def _add_card(name: str, annual_fee: str = "$95", fee_date: str = "") -> None:
+    import db, datetime
+    db.add_card({
+        "name": name,
+        "annual_fee": annual_fee,
+        "date_added": datetime.date.today().isoformat(),
+        "fee_date": fee_date,
+    })
+
+
+# ===========================================================================
+# db.get_renewal_schedule()
+# ===========================================================================
+
+class TestGetRenewalSchedule:
+    def test_empty_when_no_cards(self):
+        import db
+        assert db.get_renewal_schedule() == []
+
+    def test_empty_when_no_fee_dates_set(self):
+        import db
+        _add_card("Amex Gold")
+        assert db.get_renewal_schedule() == []
+
+    def test_returns_card_with_fee_date(self):
+        import db
+        # Use a future date guaranteed to be in the future
+        future = (datetime.date.today() + datetime.timedelta(days=30)).strftime("%m-%d")
+        _add_card("Chase Sapphire Preferred", fee_date=future)
+        schedule = db.get_renewal_schedule()
+        assert len(schedule) == 1
+        assert schedule[0]["name"] == "Chase Sapphire Preferred"
+        assert schedule[0]["days_until"] == 30
+
+    def test_past_date_rolls_to_next_year(self):
+        import db
+        # Use yesterday's MM-DD — should roll forward ~365 days
+        yesterday = (datetime.date.today() - datetime.timedelta(days=1)).strftime("%m-%d")
+        _add_card("Amex Platinum", fee_date=yesterday)
+        schedule = db.get_renewal_schedule()
+        assert len(schedule) == 1
+        assert schedule[0]["days_until"] >= 364
+
+    def test_sorted_ascending_by_days(self):
+        import db
+        today = datetime.date.today()
+        soon = (today + datetime.timedelta(days=10)).strftime("%m-%d")
+        later = (today + datetime.timedelta(days=60)).strftime("%m-%d")
+        _add_card("Card A", fee_date=later)
+        _add_card("Card B", fee_date=soon)
+        schedule = db.get_renewal_schedule()
+        assert schedule[0]["name"] == "Card B"
+        assert schedule[1]["name"] == "Card A"
+        assert schedule[0]["days_until"] < schedule[1]["days_until"]
+
+    def test_skips_cards_without_fee_date(self):
+        import db
+        future = (datetime.date.today() + datetime.timedelta(days=20)).strftime("%m-%d")
+        _add_card("Card With Date", fee_date=future)
+        _add_card("Card No Date")
+        schedule = db.get_renewal_schedule()
+        assert len(schedule) == 1
+        assert schedule[0]["name"] == "Card With Date"
+
+    def test_next_renewal_is_iso_date_string(self):
+        import db
+        future = (datetime.date.today() + datetime.timedelta(days=15)).strftime("%m-%d")
+        _add_card("Citi Double Cash", fee_date=future)
+        schedule = db.get_renewal_schedule()
+        # Should be parseable as an ISO date
+        datetime.date.fromisoformat(schedule[0]["next_renewal"])
+
+
+# ===========================================================================
+# CLI: cards fee-date
+# ===========================================================================
+
+class TestCardsFeeDate:
+    def test_sets_fee_date(self):
+        _add_card("Amex Gold")
+        result = runner.invoke(app, ["cards", "fee-date", "Amex Gold", "03-15"])
+        assert result.exit_code == 0
+        assert "Amex Gold" in result.output
+        assert "03-15" in result.output
+
+    def test_partial_name_match(self):
+        _add_card("Chase Sapphire Preferred")
+        result = runner.invoke(app, ["cards", "fee-date", "sapphire", "06-01"])
+        assert result.exit_code == 0
+        assert "Chase Sapphire Preferred" in result.output
+
+    def test_ambiguous_match_exits_1(self):
+        _add_card("Chase Sapphire Preferred")
+        _add_card("Chase Sapphire Reserve")
+        result = runner.invoke(app, ["cards", "fee-date", "sapphire", "06-01"])
+        assert result.exit_code == 1
+
+    def test_no_match_exits_1(self):
+        result = runner.invoke(app, ["cards", "fee-date", "nonexistent", "01-01"])
+        assert result.exit_code == 1
+
+    def test_invalid_format_exits_1(self):
+        _add_card("Amex Gold")
+        result = runner.invoke(app, ["cards", "fee-date", "Amex Gold", "January 15"])
+        assert result.exit_code == 1
+
+    def test_invalid_date_value_exits_1(self):
+        _add_card("Amex Gold")
+        result = runner.invoke(app, ["cards", "fee-date", "Amex Gold", "99-99"])
+        assert result.exit_code == 1
+
+    def test_json_output(self):
+        _add_card("Amex Gold")
+        result = runner.invoke(app, ["cards", "fee-date", "Amex Gold", "01-15", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["fee_date"] == "01-15"
+        assert data["card"] == "Amex Gold"
+
+    def test_date_persisted_in_db(self):
+        import db
+        _add_card("Citi Double Cash")
+        runner.invoke(app, ["cards", "fee-date", "Citi Double Cash", "07-20"])
+        card = db.get_card("Citi Double Cash")
+        assert card["fee_date"] == "07-20"
+
+
+# ===========================================================================
+# CLI: cards renewal
+# ===========================================================================
+
+class TestCardsRenewal:
+    def test_no_cards_shows_empty_message(self):
+        result = runner.invoke(app, ["cards", "renewal"])
+        assert result.exit_code == 0
+        assert "No cards" in result.output
+
+    def test_card_without_fee_date_appears_in_no_date_list(self):
+        _add_card("Amex Gold")
+        result = runner.invoke(app, ["cards", "renewal"])
+        assert result.exit_code == 0
+        assert "Amex Gold" in result.output
+        assert "fee date" in result.output.lower()
+
+    def test_card_with_fee_date_appears_in_schedule(self):
+        future = (datetime.date.today() + datetime.timedelta(days=45)).strftime("%m-%d")
+        _add_card("Chase Sapphire Preferred", fee_date=future)
+        result = runner.invoke(app, ["cards", "renewal"])
+        assert result.exit_code == 0
+        assert "Chase Sapphire Preferred" in result.output
+        assert "45d" in result.output
+
+    def test_days_filter_excludes_far_renewals(self):
+        future = (datetime.date.today() + datetime.timedelta(days=90)).strftime("%m-%d")
+        _add_card("Amex Gold", fee_date=future)
+        result = runner.invoke(app, ["cards", "renewal", "--days", "30"])
+        assert result.exit_code == 0
+        assert "No upcoming renewals" in result.output
+
+    def test_days_filter_includes_near_renewals(self):
+        future = (datetime.date.today() + datetime.timedelta(days=20)).strftime("%m-%d")
+        _add_card("Amex Gold", fee_date=future)
+        result = runner.invoke(app, ["cards", "renewal", "--days", "30"])
+        assert result.exit_code == 0
+        assert "Amex Gold" in result.output
+
+    def test_json_output_shape(self):
+        future = (datetime.date.today() + datetime.timedelta(days=10)).strftime("%m-%d")
+        _add_card("Citi Double Cash", fee_date=future)
+        _add_card("Capital One Venture")
+        result = runner.invoke(app, ["cards", "renewal", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["command"] == "renewal"
+        assert len(data["schedule"]) == 1
+        assert data["schedule"][0]["name"] == "Citi Double Cash"
+        assert "no_date_set" in data
+        assert "Capital One Venture" in data["no_date_set"]
+
+    def test_schedule_sorted_by_days_ascending(self):
+        today = datetime.date.today()
+        soon  = (today + datetime.timedelta(days=5)).strftime("%m-%d")
+        later = (today + datetime.timedelta(days=50)).strftime("%m-%d")
+        _add_card("Card Soon",  fee_date=soon)
+        _add_card("Card Later", fee_date=later)
+        result = runner.invoke(app, ["cards", "renewal", "--json"])
+        data = json.loads(result.output)
+        names = [c["name"] for c in data["schedule"]]
+        assert names == ["Card Soon", "Card Later"]
+
+
+# ===========================================================================
+# CLI: cards add --fee-date
+# ===========================================================================
+
+class TestCardsAddWithFeeDate:
+    def test_add_with_fee_date_stores_it(self):
+        import db
+        result = runner.invoke(app, [
+            "cards", "add", "Amex Platinum", "--fee", "$695", "--fee-date", "02-28"
+        ])
+        assert result.exit_code == 0
+        card = db.get_card("Amex Platinum")
+        assert card["fee_date"] == "02-28"
+
+    def test_add_without_fee_date_stores_empty(self):
+        import db
+        result = runner.invoke(app, ["cards", "add", "Citi Double Cash"])
+        assert result.exit_code == 0
+        card = db.get_card("Citi Double Cash")
+        assert card["fee_date"] == ""


### PR DESCRIPTION
## Summary

- **Annual fee renewal tracker** — CLI (`fleece cards renewal`, `fleece cards fee-date`) and iOS Wallet tab section let users track when each card's annual fee is due; dates persist in SQLite (CLI) and UserDefaults (iOS)
- **Annual Fee Calendar widget** — new WidgetKit widget in small (next renewal) and medium (up to 3 renewals) sizes with color-coded urgency; refreshes at midnight
- **New cards** — added Robinhood Gold Card (3% on everything, $50/yr), Wells Fargo Active Cash (2% on everything, $0), and Discover it Cash Back (5% rotating: gas/groceries/dining/drugstore, $0)
- **WidgetKit extension** — four widget sizes for "Best Card Nearby" (small, medium, lock screen rectangular, lock screen circular)
- **24 unit tests** covering `db.get_renewal_schedule()`, `cards fee-date`, `cards renewal`, and `cards add --fee-date`

## Test plan

- [ ] `python -m pytest tests/test_renewal.py -v` — all 24 tests pass
- [ ] `fleece cards add "Amex Gold" --fee "$250" --fee-date 01-15` then `fleece cards renewal` shows the schedule
- [ ] iOS: add a card to wallet → Annual Fee Calendar section appears → tap Set → date picker works → days remaining updates
- [ ] iOS widget: add Annual Fee Calendar widget from home screen long-press → small shows next renewal, medium shows up to 3
- [ ] New cards (Robinhood Gold, Active Cash, Discover it) visible in Wallet → Add to Wallet list

🤖 Generated with [Claude Code](https://claude.com/claude-code)